### PR TITLE
fix: manage all codebuild env variables from CodeBuildFactory

### DIFF
--- a/packages/@cdklabs/cdk-cicd-wrapper/src/resource-providers/CodeBuildFactoryProvider.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/resource-providers/CodeBuildFactoryProvider.ts
@@ -43,6 +43,8 @@ export class CodeBuildFactoryProvider implements IResourceProvider {
     const phaseCommandsProvider = context.get(GlobalResources.PHASE);
 
     return new DefaultCodeBuildFactory({
+      applicationQualifier: context.blueprintProps.applicationQualifier,
+      region: context.blueprintProps.deploymentDefinition.RES.env.region,
       resAccount: context.blueprintProps.deploymentDefinition.RES.env.account,
       vpc,
       proxyConfig,
@@ -55,6 +57,14 @@ export class CodeBuildFactoryProvider implements IResourceProvider {
 }
 
 export interface DefaultCodeBuildFactoryProps {
+  /**
+   * The applicationQualifier used for the pipeline.
+   */
+  readonly applicationQualifier: string;
+  /**
+   * The AWS region to set.
+   */
+  readonly region: string;
   /**
    * The account ID of the RES stage
    */
@@ -150,6 +160,9 @@ export class DefaultCodeBuildFactory implements ICodeBuildFactory {
   protected generateBuildEnvironmentVariables(props: DefaultCodeBuildFactoryProps): Record<string, string> {
     const proxyConfig = props.proxyConfig;
     const envVariables: Record<string, string> = {};
+
+    envVariables.CDK_QUALIFIER = props.applicationQualifier;
+    envVariables.AWS_REGION = props.region;
 
     if (proxyConfig) {
       envVariables.AWS_STS_REGIONAL_ENDPOINTS = 'regional';

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/resource-providers/CodeBuildFactoryProvider.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/resource-providers/CodeBuildFactoryProvider.ts
@@ -158,7 +158,7 @@ export class DefaultCodeBuildFactory implements ICodeBuildFactory {
    * @returns An object containing the build environment variables
    */
   protected generateBuildEnvironmentVariables(props: DefaultCodeBuildFactoryProps): Record<string, string> {
-    const proxyConfig = props.proxyConfig;
+    const { proxyConfig, npmRegistry } = props;
     const envVariables: Record<string, string> = {};
 
     envVariables.CDK_QUALIFIER = props.applicationQualifier;
@@ -167,6 +167,13 @@ export class DefaultCodeBuildFactory implements ICodeBuildFactory {
     if (proxyConfig) {
       envVariables.AWS_STS_REGIONAL_ENDPOINTS = 'regional';
       envVariables.NO_PROXY = proxyConfig.noProxy.join(','); // Comma-separated list of hosts that should bypass the proxy
+      envVariables.PROXY_SECRET_ARN = proxyConfig.proxySecretArn;
+    }
+
+    if (npmRegistry) {
+      envVariables.NPM_REGISTRY = npmRegistry.url;
+      envVariables.NPM_BASIC_AUTH_SECRET_ID = npmRegistry.basicAuthSecretArn;
+      envVariables.NPM_SCOPE = npmRegistry.scope ?? '';
     }
 
     return envVariables;

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/resource-providers/PipelineProvider.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/resource-providers/PipelineProvider.ts
@@ -31,14 +31,6 @@ export class PipelineProvider implements IResourceProvider {
       repositoryInput: repositoryProvider.pipelineInput,
       branch: repositoryProvider.repositoryBranch,
       pipelineVariables: {
-        PROXY_SECRET_ARN: proxy?.proxySecretArn ?? '',
-        ...(blueprintProps.npmRegistry
-          ? {
-              NPM_REGISTRY: blueprintProps.npmRegistry.url,
-              NPM_BASIC_AUTH_SECRET_ID: blueprintProps.npmRegistry.basicAuthSecretArn,
-              NPM_SCOPE: blueprintProps.npmRegistry.scope ?? '',
-            }
-          : {}),
         ...repositoryProvider.pipelineEnvVars,
       },
       vpcProps: vpcProvider.vpc

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/stacks/PipelineBlueprintStack.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/stacks/PipelineBlueprintStack.test.ts
@@ -51,26 +51,16 @@ describe('pipeline-blueprint-stack-test-codecommit', () => {
   });
 
   test('Check if Pipeline ENV variables exist', () => {
-    template.hasResourceProperties('AWS::CodeBuild::Project', {
-      Environment: {
-        EnvironmentVariables: [
-          {
-            Name: 'CDK_QUALIFIER',
-            Type: 'PLAINTEXT',
-            Value: TestAppConfig.applicationQualifier,
-          },
-          {
-            Name: 'AWS_REGION',
-            Type: 'PLAINTEXT',
-            Value: TestAppConfig.deploymentDefinition.RES.env.region,
-          },
-          {
-            Name: 'PROXY_SECRET_ARN',
-            Type: 'PLAINTEXT',
-            Value: '',
-          },
-        ],
-      },
+    const codeBuildProjects = template.findResources('AWS::CodeBuild::Project');
+
+    Object.values(codeBuildProjects).forEach((project) => {
+      Match.stringLikeRegexp(`.*CDK_QUALIFIER:${TestAppConfig.applicationQualifier}.*`).test(
+        project.Properties.Source.BuildSpec,
+      );
+      Match.stringLikeRegexp(`.*AWS_REGION:${TestAppConfig.deploymentDefinition.RES.env.region}.*`).test(
+        project.Properties.Source.BuildSpec,
+      );
+      Match.stringLikeRegexp('.*(?!PROXY_SECRET_ARN).*').test(project.Properties.Source.BuildSpec);
     });
   });
 
@@ -145,31 +135,18 @@ describe('pipeline-stack-test-codestar', () => {
   );
 
   test('Check if Pipeline ENV variables exist', () => {
-    template.hasResourceProperties('AWS::CodeBuild::Project', {
-      Environment: {
-        EnvironmentVariables: [
-          {
-            Name: 'CDK_QUALIFIER',
-            Type: 'PLAINTEXT',
-            Value: TestAppConfig.applicationQualifier,
-          },
-          {
-            Name: 'AWS_REGION',
-            Type: 'PLAINTEXT',
-            Value: TestAppConfig.deploymentDefinition.RES.env.region,
-          },
-          {
-            Name: 'PROXY_SECRET_ARN',
-            Type: 'PLAINTEXT',
-            Value: '',
-          },
-          {
-            Name: 'CODESTAR_CONNECTION_ARN',
-            Type: 'PLAINTEXT',
-            Value: TestRepositoryConfigGithub.codeStarConnectionArn,
-          },
-        ],
-      },
+    const codeBuildProjects = template.findResources('AWS::CodeBuild::Project');
+    Object.values(codeBuildProjects).forEach((project) => {
+      Match.stringLikeRegexp(`.*CDK_QUALIFIER:${TestAppConfig.applicationQualifier}.*`).test(
+        project.Properties.Source.BuildSpec,
+      );
+      Match.stringLikeRegexp(`.*AWS_REGION:${TestAppConfig.deploymentDefinition.RES.env.region}.*`).test(
+        project.Properties.Source.BuildSpec,
+      );
+      Match.stringLikeRegexp('.*(?!PROXY_SECRET_ARN).*').test(project.Properties.Source.BuildSpec);
+      Match.stringLikeRegexp(`.*CODESTAR_CONNECTION_ARN:${TestRepositoryConfigGithub.codeStarConnectionArn}.*`).test(
+        project.Properties.Source.BuildSpec,
+      );
     });
   });
 
@@ -347,23 +324,6 @@ describe('pipeline-stack-test-proxy-vpc', () => {
       Description: 'Pipeline step PipelineStackExtendingStage/Pipeline/Build/Synth',
       Environment: {
         ComputeType: 'BUILD_GENERAL1_SMALL',
-        EnvironmentVariables: [
-          {
-            Name: 'AWS_REGION',
-            Type: 'PLAINTEXT',
-            Value: TestAppConfig.deploymentDefinition.RES.env.region,
-          },
-          {
-            Name: 'CODESTAR_CONNECTION_ARN',
-            Type: 'PLAINTEXT',
-            Value: TestRepositoryConfigGithub.codeStarConnectionArn,
-          },
-          {
-            Name: 'CDK_QUALIFIER',
-            Type: 'PLAINTEXT',
-            Value: TestAppConfig.applicationQualifier,
-          },
-        ],
         Image: TestAppConfig.codeBuildEnvSettings.buildImage,
         PrivilegedMode: TestAppConfig.codeBuildEnvSettings.privileged,
         Type: 'LINUX_CONTAINER',

--- a/samples/cdk-ts-example/.projenrc.ts
+++ b/samples/cdk-ts-example/.projenrc.ts
@@ -6,6 +6,13 @@ import { CdkCICDWrapper } from '@cdklabs/cdk-cicd-wrapper-projen';
 
 const cdkQualifier = process.env.CDK_QUALIFIER || 'simple';
 
+const eslintDeps = [
+  'eslint@^8',
+  '@typescript-eslint/eslint-plugin@^7',
+  '@typescript-eslint/parser@^7',
+  '@typescript-eslint/typescript-estree@^7',
+];
+
 const project = new awscdk.AwsCdkTypeScriptApp({
   cdkVersion: '2.1.0',
   defaultReleaseBranch: 'main',
@@ -14,6 +21,8 @@ const project = new awscdk.AwsCdkTypeScriptApp({
   packageManager: javascript.NodePackageManager.NPM,
   release: false,
 });
+
+project.addDevDeps(...eslintDeps);
 
 //@ts-ignore Projen Versions can be different during the upgrade process and would resolve complains about assignability issues.
 new CdkCICDWrapper(project, {


### PR DESCRIPTION
Fixed:
- CDK_QUALIFIER env variable was missing from  CodeBuild projects
- CodeBuild env virables were managed in two different places, it is consolidated to the CodeBuildFactory
- Upgraded eslint version in sample