### PR TITLE
fix: add doc for PROD stage, bump version to 2.162.1 in example docs

### DIFF
--- a/docs/content/developer_guides/variables.md
+++ b/docs/content/developer_guides/variables.md
@@ -8,9 +8,11 @@
 | ACCOUNT_RES |   |   | account id for resources account where pipeline will run |
 | ACCOUNT_DEV |   |   | account id for DEV environment account |
 | ACCOUNT_INT |   |   | account id for INT environment account |
+| ACCOUNT_PROD |   |   | account id for PROD environment account |
 | RES_ACCOUNT_AWS_PROFILE |   |   | sets the named profile to use for the RES account. this profile must exist in `~/.aws/credentials` or `~/.aws/config` |
 | DEV_ACCOUNT_AWS_PROFILE |   |   | sets the named profile to use for the DEV account. this profile must exist in `~/.aws/credentials` or `~/.aws/config` |
 | INT_ACCOUNT_AWS_PROFILE |   |   | sets the named profile to use for the INT account. this profile must exist in `~/.aws/credentials` or `~/.aws/config` |
+| PROD_ACCOUNT_AWS_PROFILE |   |   | sets the named profile to use for the PROD account. this profile must exist in `~/.aws/credentials` or `~/.aws/config` |
 | AWS_PROFILE |   |   | sets the default named profile to use for aws cli or cdk commands when no `--profile` is provided. set to the same value as `RES_ACCOUNT_AWS_PROFILE` this profile must exist in `~/.aws/credentials` or `~/.aws/config` |
 |             | applicationName | Wrapper | sets the name of the Application |
 | CDK_QUALIFIER | cdkQualifier | wrapper | used to distinguish between multiple deployments of a VP project in the same account. Good practice to customize per deployment. |

--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -97,7 +97,7 @@ If you are reusing an existing CDK bootstrapping setup, you can skip this step. 
    --trust ${ACCOUNT_RES} aws://${ACCOUNT_PROD}/${AWS_REGION}
    ```
 
-   **Note**: Update the variables in the command with your actual account IDs and AWS region. To activate `PROD` you need to make sure to explicitly add it into the `.defineStages([Stage.PROD])` as explained in the step 2 below. For more info on how to add custom stages please refer to [here](../developer_guides/cd.md#how-to-define-custom-stages)
+   **Note**: Update the variables in the command with your actual account IDs and AWS region. To activate `PROD`, you must explicitly include it in the `.defineStages([Stage.DEV, Stage.INT, Stage.PROD])` as outlined in step 2 below. Always specify all the stages you require; do not add only `Stage.PROD` and assume the other stages will be included automatically. For more info on how to add custom stages please refer to [here](../developer_guides/cd.md#how-to-define-custom-stages)
 
 ## Configure .gitignore
 
@@ -131,7 +131,7 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
    /**
     * To enable the `Stage.PROD` stage in your pipeline you have to explicitly add it into the `.defineStages()` hook as below.
     * In our case we have DEV, INT and PROD so we add all of them explicitly as we assume you have them all in your project.
-    * Attention: Leaving one of the stages outside of the defineStages() will leave them outside the pipeline.
+    * Attention: Any stage not included in the defineStages() function will be excluded from the pipeline.
     * This is done for safety reasons, to not export accidentally `PROD` env vars and have it deployed into the wrong account.
     */
    PipelineBlueprint.builder().defineStages([Stage.DEV, Stage.INT, Stage.PROD]).synth(app);

--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -131,6 +131,7 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
    /**
     * To enable the `Stage.PROD` stage in your pipeline you have to explicitly add it into the `.defineStages()` hook as below.
     * In our case we have DEV, INT and PROD so we add all of them explicitly as we assume you have them all in your project.
+    * Attention: Leaving one of the stages outside of the defineStages() will leave them outside the pipeline.
     * This is done for safety reasons, to not export accidentally `PROD` env vars and have it deployed into the wrong account.
     */
    PipelineBlueprint.builder().defineStages([Stage.DEV, Stage.INT, Stage.PROD]).synth(app);
@@ -142,11 +143,11 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
 
    ```typescript
    import * as cdk from 'aws-cdk-lib';
-   import { PipelineBlueprint, GlobalResources } from '@cdklabs/cdk-cicd-wrapper';
+   import { PipelineBlueprint, Stage, GlobalResources } from '@cdklabs/cdk-cicd-wrapper';
 
    const app = new cdk.App();
 
-   PipelineBlueprint.builder().addStack({
+   PipelineBlueprint.builder().defineStages([Stage.DEV, Stage.INT, Stage.PROD]).addStack({
    provide: (context) => {
       // Create your stacks here
       new YourStack(context.scope, `${context.blueprintProps.applicationName}YourStack`, {

--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -97,7 +97,7 @@ If you are reusing an existing CDK bootstrapping setup, you can skip this step. 
    --trust ${ACCOUNT_RES} aws://${ACCOUNT_PROD}/${AWS_REGION}
    ```
 
-   **Note**: Update the variables in the command with your actual account IDs and AWS region.
+   **Note**: Update the variables in the command with your actual account IDs and AWS region. To activate `PROD` you need to make sure to explicitly add it into the `.defineStages()` as explained in the step 2 below.
 
 ## Configure .gitignore
 
@@ -128,7 +128,12 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
 
    const app = new cdk.App();
 
-   PipelineBlueprint.builder().synth(app);
+   /**
+    * To enable the `PROD` stage in your pipeline you have to explicitly add it into the `.defineStages()` hook as below.
+    * In our case we have DEV, INT and PROD so we add all of them explicitly as we assume you have them all in your project.
+    * This is done for safety reasons, to not export accidentally PROD env vars and have it deployed into the wrong account.
+    */
+   PipelineBlueprint.builder().defineStages(['DEV', 'INT', 'PROD']).synth(app);
    ```
 
    This will deploy the CI/CD pipeline with its default configuration without deploying any stacks into the staging accounts.
@@ -161,7 +166,7 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
 
   4. 0. Adding cdk script (necessay when you run the `npm run cdk` and uses the local cdk version rather than the global one)
   ```bash
-   jq --arg key "cdk" --arg val "npx aws-cdk@2.142.1" '.scripts[$key] = $val' package.json | jq . > package.json.tmp; mv package.json.tmp package.json;
+   jq --arg key "cdk" --arg val "npx aws-cdk@2.162.1" '.scripts[$key] = $val' package.json | jq . > package.json.tmp; mv package.json.tmp package.json;
   ```
   4. 1. Adding validate script
    ```bash
@@ -199,7 +204,7 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
        "audit:license": "npm run license",
        "audit:scan:security": "cdk-cicd security-scan --bandit --semgrep --shellcheck --ci",
        "audit": "npx concurrently 'npm:audit:*(!fix)'",
-       "cdk": "npx aws-cdk@2.142.1",
+       "cdk": "npx aws-cdk@2.162.1",
        "license:fix": "cdk-cicd license --fix",
        "license": "cdk-cicd license",
        "lint:fix": "eslint . --ext .ts --fix",

--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -97,7 +97,7 @@ If you are reusing an existing CDK bootstrapping setup, you can skip this step. 
    --trust ${ACCOUNT_RES} aws://${ACCOUNT_PROD}/${AWS_REGION}
    ```
 
-   **Note**: Update the variables in the command with your actual account IDs and AWS region. To activate `PROD` you need to make sure to explicitly add it into the `.defineStages()` as explained in the step 2 below.
+   **Note**: Update the variables in the command with your actual account IDs and AWS region. To activate `PROD` you need to make sure to explicitly add it into the `.defineStages([Stage.PROD])` as explained in the step 2 below. For more info on how to add custom stages please refer to [here](../developer_guides/cd.md#how-to-define-custom-stages)
 
 ## Configure .gitignore
 
@@ -124,16 +124,16 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
 
    ```typescript
    import * as cdk from 'aws-cdk-lib';
-   import { PipelineBlueprint } from '{{ npm_codepipeline }}';
+   import { PipelineBlueprint, Stage } from '{{ npm_codepipeline }}';
 
    const app = new cdk.App();
 
    /**
-    * To enable the `PROD` stage in your pipeline you have to explicitly add it into the `.defineStages()` hook as below.
+    * To enable the `Stage.PROD` stage in your pipeline you have to explicitly add it into the `.defineStages()` hook as below.
     * In our case we have DEV, INT and PROD so we add all of them explicitly as we assume you have them all in your project.
-    * This is done for safety reasons, to not export accidentally PROD env vars and have it deployed into the wrong account.
+    * This is done for safety reasons, to not export accidentally `PROD` env vars and have it deployed into the wrong account.
     */
-   PipelineBlueprint.builder().defineStages(['DEV', 'INT', 'PROD']).synth(app);
+   PipelineBlueprint.builder().defineStages([Stage.DEV, Stage.INT, Stage.PROD]).synth(app);
    ```
 
    This will deploy the CI/CD pipeline with its default configuration without deploying any stacks into the staging accounts.


### PR DESCRIPTION
Fixes:
- confusing docs for adding PROD stage to the Pipeline
- adjust sample CDK Version from 2.142.1 to 2.162.1