### PR TITLE
feat: allow simplified stack namings

### DIFF
--- a/packages/@cdklabs/cdk-cicd-wrapper/test/TestConfig.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/TestConfig.ts
@@ -3,8 +3,16 @@
 
 import * as cdk from 'aws-cdk-lib';
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
-import { IPipelineConfig, CodeGuruSeverityThreshold, PipelinePhases, IStackProvider } from '../src/common';
-import { BaseRepositoryProviderProps } from '../src/resource-providers';
+import { IPipelineBlueprintProps } from '../src';
+import {
+  IPipelineConfig,
+  CodeGuruSeverityThreshold,
+  PipelinePhases,
+  IStackProvider,
+  ResourceContext,
+  GlobalResources,
+} from '../src/common';
+import { BaseRepositoryProviderProps, EncryptionProvider, HookProvider } from '../src/resource-providers';
 import { PhaseCommands } from '../src/resource-providers/PhaseCommandProvider';
 
 const codeBuildEnvSettings = {
@@ -69,3 +77,14 @@ export const TestStackProvider: IStackProvider = {
     });
   },
 };
+
+export const TestContext: (props?: Partial<IPipelineBlueprintProps>) => ResourceContext = (props) =>
+  new ResourceContext(new cdk.App(), new cdk.Stack(), {
+    ...TestAppConfig,
+    resourceProviders: {
+      [GlobalResources.ENCRYPTION]: new EncryptionProvider(),
+      [GlobalResources.HOOK]: new HookProvider(),
+    },
+    plugins: {},
+    ...(props ?? {}),
+  });

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/common/types/DefaultStackProvider.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/common/types/DefaultStackProvider.test.ts
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as cdk from 'aws-cdk-lib';
+import { Stage } from '../../../src';
+import { DefaultStackProvider } from '../../../src/common/types/DefaultStackProvider';
+import { TestContext } from '../../TestConfig';
+
+describe('DefaultStackProvider', () => {
+  let testContext = TestContext();
+
+  beforeEach(() => {
+    testContext = TestContext();
+  });
+
+  test('should have random stacknames', () => {
+    const provider = new (class extends DefaultStackProvider {
+      stacks(): void {
+        const stack = new cdk.Stack(this.scope, 'Stack1');
+
+        new cdk.CfnOutput(stack, 'Output1', {
+          value: 'Output1',
+        });
+      }
+    })({
+      providerName: 'TestProvider',
+    });
+
+    testContext.initStage(Stage.DEV);
+    testContext._scoped(new cdk.Stage(testContext.scope, 'DEV'), () => {
+      provider.provide(testContext);
+    });
+
+    (testContext.scope as cdk.App).synth();
+
+    expect(
+      testContext.scope.node
+        .findAll()
+        .filter((node) => node.node.id === 'Stack1')
+        .map((node) => node as cdk.Stack)
+        .map((stack) => stack.stackName)
+        .at(0),
+    ).toMatch(/^DEV-CICDWrapperTestProviderStack1.{8}/g);
+  });
+
+  test('should have normalized stacknames', () => {
+    const provider = new (class extends DefaultStackProvider {
+      stacks(): void {
+        const stack = new cdk.Stack(this.scope, 'Stack1');
+
+        new cdk.CfnOutput(stack, 'Output1', {
+          value: 'Output1',
+        });
+      }
+    })({
+      providerName: 'TestProvider',
+      normalizeStackNames: true,
+    });
+
+    testContext.initStage(Stage.DEV);
+    testContext._scoped(new cdk.Stage(testContext.scope, 'DEV'), () => {
+      provider.provide(testContext);
+    });
+
+    (testContext.scope as cdk.App).synth();
+
+    expect(
+      testContext.scope.node
+        .findAll()
+        .filter((node) => node.node.id === 'Stack1')
+        .map((node) => node as cdk.Stack)
+        .map((stack) => stack.stackName)
+        .at(0),
+    ).toMatch(/^DEV-CICDWrapper-TestProvider-Stack1$/g);
+  });
+});


### PR DESCRIPTION
Changed:
- Added a new parameter normalizeStackNames to the Default Provider to remove the random id's from end of the stack names