### PR TITLE
fix: missing link of the documentation

### DIFF
--- a/docs/content/developer_guides/.pages.yml
+++ b/docs/content/developer_guides/.pages.yml
@@ -16,6 +16,7 @@ nav:
     - "AWS CodeArtifact": "codeartifact.md"
     - "Private NPM Registry": "private_npm_registry.md"
   - "GIT Integrations":
+    - "Amazon S3": "vcs_s3.md"
     - "CodeCommit": "vcs_codecommit.md"
     - "GitHub": "vcs_github.md"
   - "Networking": "networking.md"

--- a/docs/content/developer_guides/vcs_s3.md
+++ b/docs/content/developer_guides/vcs_s3.md
@@ -1,10 +1,11 @@
-# S3-based Git Repository Integration
+# Amazon S3 based Git Repository Integration
 
 As AWS CodeCommit will be deemphasized after July 25, 2024, you can use S3 as a Git repository with {{ project_name }}. This approach uses the [git-remote-s3](https://github.com/awslabs/git-remote-s3) tool to enable S3 as a git remote and LFS server.
 
 ## Prerequisites
 
-1. Install the git-remote-s3 Python package:
+* Install the git-remote-s3 Python package:
+
 ```bash
 pip install git-remote-s3
 ```
@@ -69,12 +70,12 @@ git add .gitattributes
 
 ## Security Considerations
 
-- All data is encrypted at rest using S3's encryption capabilities
+- All data is encrypted at rest using Amazon S3's encryption capabilities
 - Use bucket policies and IAM roles to control access
 
 ## Using with AWS CodePipeline
 
-The S3-based repository automatically creates ZIP archives that can be used as source artifacts in AWS CodePipeline. The ZIP files are stored at:
+The Amazon S3 based repository automatically creates ZIP archives that can be used as source artifacts in AWS CodePipeline. The ZIP files are stored at:
 ```
 s3://my-git-bucket/my-repo/refs/heads/<branch>/repo.zip
 ```


### PR DESCRIPTION
### Fixes:
- sidebar link for the Amazon S3 repository has been missing
- ensure proper naming of the Amazon / AWS services