### PR TITLE
fix: update GitHub URL

### DIFF
--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -294,7 +294,7 @@ If you are using GitHub, add the remote repository and push your local repositor
 
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD);
-git remote add origin git@github:${GIT_REPOSITORY}.git;
+git remote add origin git@github.com:${GIT_REPOSITORY}.git;
 git commit -am "feat: init origin";
 git push -u origin ${CURRENT_BRANCH}:main
 ```


### PR DESCRIPTION
Add `.com` to GitHub origin to use the correct GitHub URL.

FYI: When you create a new empty repo on GitHub, you can see the valid URL which includes `.com`:
```bash
git remote add origin git@github.com:jumic/pipeline-ci-cd-wrapper.git
```