### PR TITLE
chore(docs): consistently include the RES stage in defineStage methods

### DIFF
--- a/docs/content/developer_guides/cdk_context.md
+++ b/docs/content/developer_guides/cdk_context.md
@@ -6,7 +6,6 @@ When you use a construct's `.fromLookup()` method, the result of the call is cac
 ### 1. Remove cdk.context.json from .gitignore
 vi .gitignore ### remove cdk.context.json
 ### 2. Generate the cdk.context.json
-source .env ### source the env vars with the right account ids and profiles for RES/DEV/INT/PROD...
 npx dotenv-cli -- npm run cdk synth ### this command generates the cdk.context.json
 ### 3. Add the cdk.context.json to git remote
 git add cdk.context.json ### re-add cdk.context.json

--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -49,11 +49,7 @@ We suggest using the provided CLI tool to set up your local environment, as it s
 
 1. Run the `npx {{ npm_cli }}@latest configure` command and follow the instructions.
 
-2. After modifying the placeholders in the script,  source the variables:
-
-   ```bash
-   source .env
-   ```
+2. After modifying the placeholders in the script
 
    **Note**: The CLI Configure script supports the RES, DEV, INT, and PROD stages by default, but you can extend the list of stages as needed. If you plan to use a GitHub repository to host your project, you will need to know your [AWS CodeStar Connection ARN](../developer_guides/vcs_github.md).
 
@@ -97,7 +93,7 @@ If you are reusing an existing CDK bootstrapping setup, you can skip this step. 
    --trust ${ACCOUNT_RES} aws://${ACCOUNT_PROD}/${AWS_REGION}
    ```
 
-   **Note**: Update the variables in the command with your actual account IDs and AWS region. To activate `PROD`, you must explicitly include it in the `.defineStages([Stage.DEV, Stage.INT, Stage.PROD])` as outlined in step 2 below. Always specify all the stages you require; do not add only `Stage.PROD` and assume the other stages will be included automatically. For more info on how to add custom stages please refer to [here](../developer_guides/cd.md#how-to-define-custom-stages)
+   **Note**: Update the variables in the command with your actual account IDs and AWS region. To activate `PROD`, you must explicitly include it in the `.defineStages([Stage.RES, Stage.DEV, Stage.INT, Stage.PROD])` as outlined in step 2 below. Always specify all the stages you require; do not add only `Stage.PROD` and assume the other stages will be included automatically. For more info on how to add custom stages please refer to [here](../developer_guides/cd.md#how-to-define-custom-stages)
 
 ## Configure .gitignore
 
@@ -134,7 +130,7 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
     * Attention: Any stage not included in the defineStages() function will be excluded from the pipeline.
     * This is done for safety reasons, to not export accidentally `PROD` env vars and have it deployed into the wrong account.
     */
-   PipelineBlueprint.builder().defineStages([Stage.DEV, Stage.INT, Stage.PROD]).synth(app);
+   PipelineBlueprint.builder().defineStages([Stage.RES, Stage.DEV, Stage.INT, Stage.PROD]).synth(app);
    ```
 
    This will deploy the CI/CD pipeline with its default configuration without deploying any stacks into the staging accounts.
@@ -147,7 +143,7 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
 
    const app = new cdk.App();
 
-   PipelineBlueprint.builder().defineStages([Stage.DEV, Stage.INT, Stage.PROD]).addStack({
+   PipelineBlueprint.builder().defineStages([Stage.RES, Stage.DEV, Stage.INT, Stage.PROD]).addStack({
    provide: (context) => {
       // Create your stacks here
       new YourStack(context.scope, `${context.blueprintProps.applicationName}YourStack`, {


### PR DESCRIPTION
Fixed:
- Update the defineStage methods to consistently include the RES stage, ensuring proper configuration for all stages in the pipeline setup. Adjust documentation to reflect these changes. (#124)