### PR TITLE
fix(release): include chore commits in releasable commits filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ mcp-servers/debugger-mcp/.coverage
 packages/@cdklabs/cdk-cicd-wrapper/tsconfig.json
 !/.projenrc.ts
 !/.github/workflows/release.yml
+.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ mcp-servers/debugger-mcp/debugger/tools/__pycache__
 mcp-servers/debugger-mcp/tests/__pycache__
 mcp-servers/debugger-mcp/.pytest_cache
 mcp-servers/debugger-mcp/.coverage
+.worktrees
 !/.github/workflows/build.yml
 !/.mergify.yml
 !/.github/workflows/upgrade.yml
@@ -69,4 +70,3 @@ mcp-servers/debugger-mcp/.coverage
 packages/@cdklabs/cdk-cicd-wrapper/tsconfig.json
 !/.projenrc.ts
 !/.github/workflows/release.yml
-.worktrees

--- a/packages/@cdklabs/cdk-cicd-wrapper/.projen/tasks.json
+++ b/packages/@cdklabs/cdk-cicd-wrapper/.projen/tasks.json
@@ -32,7 +32,7 @@
         "RELEASE_TAG_PREFIX": "@cdklabs/cdk-cicd-wrapper@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix|chore){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
       },
       "steps": [
         {
@@ -257,7 +257,7 @@
         "RELEASE_TAG_PREFIX": "@cdklabs/cdk-cicd-wrapper@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix|chore){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
       },
       "steps": [
         {

--- a/projenrc/PipelineConfig.ts
+++ b/projenrc/PipelineConfig.ts
@@ -13,7 +13,7 @@ export class PipelineConfig extends yarn.TypeScriptWorkspace {
       description:
         'This repository contains the infrastructure as code to wrap your AWS CDK project with CI/CD around it.',
       keywords: ['cli', 'aws-cdk', 'awscdk', 'aws', 'ci-cd-boot', 'ci-cd', 'vanilla-pipeline'],
-      releasableCommits: pj.ReleasableCommits.featuresAndFixes('.'),
+      releasableCommits: pj.ReleasableCommits.ofType(['feat', 'fix', 'chore'], '.'),
       devDeps: [
         'eslint@^8',
         `cdk-pipelines-github`,

--- a/projenrc/RootConfig.ts
+++ b/projenrc/RootConfig.ts
@@ -102,6 +102,7 @@ export class RootConfig extends yarn.Monorepo {
         'mcp-servers/debugger-mcp/tests/__pycache__',
         'mcp-servers/debugger-mcp/.pytest_cache',
         'mcp-servers/debugger-mcp/.coverage',
+        '.worktrees',
       ],
     });
 


### PR DESCRIPTION
## Summary

Changes `releasableCommits` in `projenrc/PipelineConfig.ts` from `ReleasableCommits.featuresAndFixes(".")" to `ReleasableCommits.ofType(["feat", "fix", "chore"], ".")` so that dependency upgrade `chore` commits trigger releases.

## Problem

Dependency upgrade PRs use `chore(deps): upgrade dependencies` commit messages, but the previous `featuresAndFixes` filter only matched `feat` and `fix` commits. This meant dependency updates never triggered a release, leaving vulnerable dependencies in published packages.

## Changes

- `projenrc/PipelineConfig.ts`: Single-line change to include `chore` in releasable commit types
- Regenerated `.projen/tasks.json`: `RELEASABLE_COMMITS` grep pattern now includes `chore`: `^(feat|fix|chore){1}`

## Testing

- `npx projen build` passes (compile + 81/81 tests + lint)
- Verified regenerated grep pattern includes `chore` in both bump tasks

## Related

Resolves root cause identified in CDK-1.