### PR TITLE
fix(ci): add dependabot.yml with auto-approve label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - auto-approve
+    open-pull-requests-limit: 10

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ mcp-servers/debugger-mcp/.coverage
 packages/@cdklabs/cdk-cicd-wrapper/tsconfig.json
 !/.projenrc.ts
 !/.github/workflows/release.yml
+.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,3 @@ mcp-servers/debugger-mcp/.coverage
 packages/@cdklabs/cdk-cicd-wrapper/tsconfig.json
 !/.projenrc.ts
 !/.github/workflows/release.yml
-.worktrees


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to configure Dependabot for npm dependency updates with the `auto-approve` label.

## Problem

The existing `auto-approve.yml` workflow checks for the `auto-approve` label on PRs, but Dependabot PRs were never labeled — so the auto-approve workflow never triggered (CDK-13).

## Changes

- Created `.github/dependabot.yml` with:
  - `package-ecosystem: npm`
  - `schedule: weekly`
  - `labels: [auto-approve]`
  - `open-pull-requests-limit: 10`

## Verification

- YAML validated with Node.js yaml parser
- Label matches `auto-approve.yml` condition: `contains(labels, 'auto-approve')`
- No projen-generated files modified
- Conventional commit format used

Resolves CDK-13.