### PR TITLE
fix: enable trusted publishing for PyPI and NuGet, remove legacy Maven endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,6 @@ jobs:
         continue-on-error: true
       - name: Release
         env:
-          MAVEN_ENDPOINT: https://s01.oss.sonatype.org
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
@@ -179,6 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     environment: release
     if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-cdklabs-cdk-cicd-wrapper == 'true' }}
     steps:
@@ -198,8 +198,7 @@ jobs:
         continue-on-error: true
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi
   cdklabs-cdk-cicd-wrapper_release_nuget:
     name: "@cdklabs/cdk-cicd-wrapper: Publish to NuGet Gallery"
@@ -207,6 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     environment: release
     if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-cdklabs-cdk-cicd-wrapper == 'true' }}
     steps:
@@ -226,7 +226,8 @@ jobs:
         continue-on-error: true
       - name: Release
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_TRUSTED_PUBLISHER: "true"
+          NUGET_USERNAME: ${{ secrets.NUGET_USERNAME }}
         run: npx -p publib@latest publib-nuget
   cdklabs-cdk-cicd-wrapper-cli_release_github:
     name: "@cdklabs/cdk-cicd-wrapper-cli: Publish to GitHub Releases"

--- a/projenrc/PipelineConfig.ts
+++ b/projenrc/PipelineConfig.ts
@@ -61,7 +61,6 @@ export class PipelineConfig extends yarn.TypeScriptWorkspace {
         javaPackage: `io.github.cdklabs.${changeDelimiter(packageBasename, '.')}`,
         mavenGroupId: `io.github.cdklabs`,
         mavenArtifactId: packageBasename,
-        mavenEndpoint: 'https://s01.oss.sonatype.org',
       },
       publishToNuget: {
         dotNetNamespace: `${upperCaseName('cdklabs')}.${upperCaseName(packageBasename)}`,

--- a/projenrc/jsiicomponent.ts
+++ b/projenrc/jsiicomponent.ts
@@ -116,6 +116,7 @@ export class JSIIComponent extends pj.Component {
       this.publisher?.publishToPyPi({
         ...this.pacmakForLanguage('python', task),
         ...pypi,
+        trustedPublishing: true,
       });
 
       this.addPackagingTarget('python', task, extraJobOptions);
@@ -133,6 +134,7 @@ export class JSIIComponent extends pj.Component {
       this.publisher?.publishToNuget({
         ...this.pacmakForLanguage('dotnet', task),
         ...nuget,
+        trustedPublishing: true,
       });
 
       this.addPackagingTarget('dotnet', task, extraJobOptions);


### PR DESCRIPTION
## Summary

Enable trusted publishing (OIDC) for PyPI and NuGet releases, and remove the legacy Maven endpoint that returns 401.

## Changes

### projenrc/jsiicomponent.ts
- Added `trustedPublishing: true` to `publishToPyPi()` call
- Added `trustedPublishing: true` to `publishToNuget()` call

### projenrc/PipelineConfig.ts
- Removed `mavenEndpoint: "https://s01.oss.sonatype.org"` — this endpoint no longer exists and returns 401

### .github/workflows/release.yml (generated)
- PyPI job: `TWINE_USERNAME`/`TWINE_PASSWORD` replaced with `PYPI_TRUSTED_PUBLISHER: "true"` + `id-token: write`
- NuGet job: `NUGET_API_KEY` replaced with `NUGET_TRUSTED_PUBLISHER: "true"` + `id-token: write`
- Maven job: `MAVEN_ENDPOINT` env var removed

## Context

Follows PRs #168 and #169 which fixed npm trusted publishing. Run 24508070179 showed npm succeeding but Maven, PyPI, and NuGet still failing.

## Testing

- `npx projen` ran successfully
- Generated workflow diff reviewed and verified
- Husky hooks passed (commitlint + lint)