### PR TITLE
fix: Add mavenServerId to publishToMaven configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,7 @@ jobs:
         continue-on-error: true
       - name: Release
         env:
+          MAVEN_SERVER_ID: central-ossrh
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/projenrc/PipelineConfig.ts
+++ b/projenrc/PipelineConfig.ts
@@ -61,6 +61,7 @@ export class PipelineConfig extends yarn.TypeScriptWorkspace {
         javaPackage: `io.github.cdklabs.${changeDelimiter(packageBasename, '.')}`,
         mavenGroupId: `io.github.cdklabs`,
         mavenArtifactId: packageBasename,
+        mavenServerId: 'central-ossrh',
       },
       publishToNuget: {
         dotNetNamespace: `${upperCaseName('cdklabs')}.${upperCaseName(packageBasename)}`,


### PR DESCRIPTION
This pull request makes a minor configuration update to the `PipelineConfig` class to improve Maven publishing settings.

* Maven Publishing Configuration:
  * Added the `mavenServerId: 'central-ossrh'` property to the `publishToMaven` configuration in `PipelineConfig.ts` to specify the server ID for publishing artifacts to Maven Central.