### PR TITLE
fix: correct DockerCredential.ecr() example in docs

### DIFF
--- a/docs/content/developer_guides/pipeline_options.md
+++ b/docs/content/developer_guides/pipeline_options.md
@@ -52,9 +52,12 @@ Necessary for projects that involve building, synthesizing, updating, or publish
 ```typescript
 import { PipelineBlueprint } from '@cdklabs/cdk-cicd-wrapper';
 import { DockerCredential } from 'aws-cdk-lib/pipelines';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+
+const privateRepo = ecr.Repository.fromRepositoryName(scope, 'PrivateRepo', 'my-private-repo');
 
 const dockerCreds: DockerCredential[] = [
-    DockerCredential.ecr('arn:aws:iam::123456789012:role/MyECRRole'),
+    DockerCredential.ecr([privateRepo]),
 ];
 
 const pipeline = PipelineBlueprint.builder()


### PR DESCRIPTION
## Summary
- The `dockerCredentials` example in `pipeline_options.md` passed an IAM role ARN string to `DockerCredential.ecr()`, but the actual `aws-cdk-lib` signature is `DockerCredential.ecr(repositories: ecr.IRepository[], opts?)`. The example didn't type-check.
- Updated the example to construct an `ecr.IRepository` and pass it in an array, matching the real API.

Related to #63, which asks for private ECR base image support for Docker Lambdas — the feature already exists via `pipelineOptions.dockerCredentials`; this fixes the broken doc example so users can actually copy-paste it.

## Test plan
- [x] Diff reviewed, change is docs-only (no source/test code affected)
- [x] Verified `DockerCredential.ecr()` signature against `aws-cdk-lib/pipelines/lib/docker-credentials.d.ts`