### PR TITLE
fix: stop the .claude PATH override from breaking every hook, and true up drifted docs

### DIFF
--- a/.claude/hooks/guard-tmp-confinement.sh
+++ b/.claude/hooks/guard-tmp-confinement.sh
@@ -8,6 +8,13 @@
 # only against its own simple command; obfuscated writes (eval/xargs) are out of scope.
 set -uo pipefail
 
+# Preflight before doing any work: this guard reads its payload with jq, so without jq it cannot judge
+# a single tool call and would fail open silently on every one of them. Say so once, visibly, instead.
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' '{"systemMessage":"tmp-confinement guard is OFF: jq did not resolve on PATH, so the hook cannot read its payload. Scratch writes are unguarded until jq is available (devbox.json pins jq 1.7.1). See .claude/hooks/preflight-toolchain.sh."}'
+  exit 0
+fi
+
 input=$(cat)
 tool=$(jq -r '.tool_name // ""' <<<"$input")
 ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"

--- a/.claude/hooks/preflight-toolchain.sh
+++ b/.claude/hooks/preflight-toolchain.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# SessionStart preflight: report which toolchain interpreters actually resolve on this machine's PATH,
+# and hand back a prepend directory chosen ONLY from candidates that exist and really contain node.
+#
+# Why this exists: `.claude/settings.json` used to pin `env.PATH` to a hardcoded nvm bin dir. Claude
+# Code does NOT interpolate `${PATH}`/`$PATH` in `env` -- the value arrives verbatim -- so that entry
+# REPLACED the session PATH with two non-existent directories. Every hook that resolves an executable
+# by name then failed with exit 127 (`/bin/sh: bash: command not found`, `/bin/sh: python3: command not
+# found`) on every prompt and every tool call. Test the path, then print it; never set it blind.
+#
+# This is the one hook that has to survive exactly that state, so it uses NOTHING from PATH: an absolute
+# interpreter, and only shell builtins (printf, case, [[, parameter expansion) -- no sort/tail/sed/jq.
+# A preflight that shells out to coreutils cannot report that coreutils is unreachable. Always exits 0.
+set -u
+
+missing=''
+for tool in node yarn jq python3; do
+  command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+done
+
+# What major does CI build on? Read it out of the workflows rather than hardcoding a number that goes
+# stale the moment CI bumps. Pure builtins: `read` on a file, glob matching via `case`. `lts/*` carries
+# no major, so it is skipped; the highest pinned major wins.
+ci_major=''
+for wf in "${CLAUDE_PROJECT_DIR:-$PWD}"/.github/workflows/*.yml; do
+  [[ -r "$wf" ]] || continue
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      *node-version:*)
+        v="${line#*node-version:}"
+        v="${v//[\"\' ]/}"                 # strip quotes and spaces
+        v="${v%%.*}"                       # "24.1" -> "24"
+        case "$v" in
+          ''|*[!0-9]*) continue ;;         # skips lts/*, latest, ${{ ... }}
+        esac
+        if [[ -z "$ci_major" || $v -gt $ci_major ]]; then ci_major="$v"; fi ;;
+    esac
+  done < "$wf"
+done
+
+# A candidate counts only if it exists AND holds an executable node. Preference order: a major matching
+# CI first (a local pass on CI's major is the evidence that counts), then newest installed, compared on
+# zero-padded numeric components so v9 does not sort above v20.
+node_bin=''
+best_key=''
+ci_bin=''
+ci_key=''
+for cand in "${NVM_DIR:-$HOME/.nvm}"/versions/node/*/bin "$HOME"/.nvm/versions/node/*/bin; do
+  [[ -x "$cand/node" ]] || continue
+  ver="${cand%/bin}"; ver="${ver##*/}"; ver="${ver#v}"
+  IFS=. read -r major minor patch _ <<<"$ver"
+  key=''
+  for part in "${major:-0}" "${minor:-0}" "${patch:-0}"; do
+    part="${part%%[!0-9]*}"
+    printf -v padded '%05d' "${part:-0}"
+    key="$key$padded"
+  done
+  if [[ -z "$best_key" || "$key" > "$best_key" ]]; then best_key="$key"; node_bin="$cand"; fi
+  # Highest patch within CI's major.
+  if [[ -n "$ci_major" && "${major:-}" == "$ci_major" ]]; then
+    if [[ -z "$ci_bin" || "$key" > "$ci_key" ]]; then ci_key="$key"; ci_bin="$cand"; fi
+  fi
+done
+node_from_ci_major='no'
+if [[ -n "$ci_bin" ]]; then node_bin="$ci_bin"; node_from_ci_major='yes'; fi
+if [[ -z "$node_bin" ]]; then
+  for cand in \
+    "${CLAUDE_PROJECT_DIR:-$PWD}/.devbox/nix/profile/default/bin" \
+    /opt/homebrew/bin \
+    /usr/local/bin
+  do
+    if [[ -x "$cand/node" ]]; then node_bin="$cand"; break; fi
+  done
+fi
+
+# The literal text below contains no " or \, so $node_bin is the only value that could break the JSON.
+# Rather than shell out to escape it, drop a pathological path from the message -- the advice to run
+# `devbox shell` is still correct, and emitting invalid JSON here would silently kill the hook.
+case "$node_bin" in *'"'*|*'\'*) node_bin='' ;; esac
+
+if [[ -z "$missing" ]]; then
+  msg='Toolchain preflight: node, yarn, jq and python3 all resolve on PATH. Nothing to do.'
+else
+  msg="Toolchain preflight: not on PATH ->$missing."
+  if [[ -n "$node_bin" ]]; then
+    msg="$msg Verified toolchain dir on this machine: $node_bin -- prepend it (PATH=DIR:\$PATH)"
+    msg="$msg in the shell you run commands in, per CLAUDE.md Toolchain."
+    if [[ "$node_from_ci_major" == 'yes' ]]; then
+      msg="$msg This one matches the node major CI builds on ($ci_major)."
+    elif [[ -n "$ci_major" ]]; then
+      msg="$msg NOTE: no installed node matches CI's major ($ci_major), so a local-only pass here is"
+      msg="$msg weaker evidence than a CI run."
+    fi
+  else
+    msg="$msg No usable node bin dir in the usual places, so enter devbox shell instead"
+    msg="$msg (devbox.json pins the toolchain)."
+  fi
+  msg="$msg Do NOT add PATH to .claude/settings.json env: values there are not interpolated, so it"
+  msg="$msg replaces the session PATH and breaks every hook with exit 127."
+fi
+
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$msg"
+exit 0

--- a/.claude/schemas/findings.schema.json
+++ b/.claude/schemas/findings.schema.json
@@ -28,9 +28,9 @@
           "type": "string"
         },
         "component": {
-          "description": "Ownership axis — the three published packages in packages/@cdklabs/ (see CLAUDE.md -> 'Toolchain'), plus 'shared' for findings that genuinely span more than one (e.g. a type exported by cdk-cicd-wrapper and consumed by the CLI, or the register hook contract the CLI's exec depends on). Findings about process, tooling, samples, or docs that aren't about a specific package (e.g. this schema file, projen config, the test harness) go under 'infra'. 'wrapper' = @cdklabs/cdk-cicd-wrapper (the jsii constructs library). 'cli' = @cdklabs/cdk-cicd-wrapper-cli. 'projen' = @cdklabs/cdk-cicd-wrapper-projen.",
+          "description": "Ownership axis — the two published packages in packages/@cdklabs/ (see CLAUDE.md -> 'Toolchain'), plus 'shared' for findings that genuinely span more than one (e.g. a type exported by cdk-cicd-wrapper and consumed by the CLI, or the register hook contract the CLI's exec depends on). Findings about process, tooling, samples, or docs that aren't about a specific package (e.g. this schema file, projen config, the test harness) go under 'infra'. 'wrapper' = @cdklabs/cdk-cicd-wrapper (the jsii constructs library). 'cli' = @cdklabs/cdk-cicd-wrapper-cli. There was a third value, 'projen' (@cdklabs/cdk-cicd-wrapper-projen); v3 removed that package (task.md D5, consolidation 3→2) and no finding used the value, so it was retired with it.",
           "type": "string",
-          "enum": ["wrapper", "cli", "projen", "shared", "infra"]
+          "enum": ["wrapper", "cli", "shared", "infra"]
         },
         "layer": {
           "description": "Detection axis, kept tool-agnostic so new checks don't need a new value: 'static' = found without executing anything (eslint/tsc, jsii compile, 'npx projen compat', security-review/code-review skill output, design/planning discussion). 'dynamic' = found by executing code outside production (today: jest unit tests, and the real-AWS deploy harness in task.md Phase 0; tomorrow: any other test framework). 'production' = surfaced by observing a live environment (monitoring, alarms, a real incident) — no current producer emits this; reserved for that future case.",

--- a/.claude/schemas/tasks.schema.json
+++ b/.claude/schemas/tasks.schema.json
@@ -36,9 +36,9 @@
           "type": "string"
         },
         "component": {
-          "description": "Ownership axis — the package/area the task touches (same axis as findings.schema.json). 'wrapper' = @cdklabs/cdk-cicd-wrapper (jsii constructs). 'cli' = @cdklabs/cdk-cicd-wrapper-cli. 'projen' = @cdklabs/cdk-cicd-wrapper-projen. 'shared' = spans packages. 'infra' = tooling/docs/samples/test-harness/schema.",
+          "description": "Ownership axis — the package/area the task touches (same axis as findings.schema.json). 'wrapper' = @cdklabs/cdk-cicd-wrapper (jsii constructs). 'cli' = @cdklabs/cdk-cicd-wrapper-cli. 'shared' = spans packages. 'infra' = tooling/docs/samples/test-harness/schema. A third value, 'projen' (@cdklabs/cdk-cicd-wrapper-projen), was retired when v3 removed that package (D5, consolidation 3→2) — no task used it.",
           "type": "string",
-          "enum": ["wrapper", "cli", "projen", "shared", "infra"]
+          "enum": ["wrapper", "cli", "shared", "infra"]
         },
         "type": {
           "description": "Work kind — drives the conventional-commit type and separates build-work from verify-work. 'spike' = time-boxed investigation with a written outcome.",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
-    "PATH": "/home/gyalai/.nvm/versions/node/v24.19.0/bin:${PATH}",
     "NODE_OPTIONS": "--max-old-space-size=6144",
     "GIT_PAGER": "cat"
   },
@@ -34,13 +33,24 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/preflight-toolchain.sh\"",
+            "statusMessage": "toolchain preflight"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit|NotebookEdit|Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-tmp-confinement.sh\"",
+            "command": "/bin/bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-tmp-confinement.sh\"",
             "statusMessage": "tmp-confinement guard"
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,39 @@ From the maintainer; these override convenience.
    of scope. Nothing is silently dropped. So the loop per unit of work is: implement → verify →
    review → disposition findings → commit.
 
+## Writing CDK resources
+
+Ground rules 1 and 2, made specific. Four checks before writing or changing a resource in
+`packages/@cdklabs/cdk-cicd-wrapper/src/**` or a fixture — each because skipping it costs a real deploy
+cycle, and a rolled-back stack is a slower teacher than five minutes of the CloudFormation reference.
+
+1. **Dependencies and update semantics.** What must exist first, what the resource requires vs. accepts
+   as optional, and above all *what an update does* — many properties are `Update requires: Replacement`,
+   so an innocuous edit destroys and recreates. This repo already learned it the expensive way: a stack
+   name that doesn't match v2's makes a migration a new stack instead of an in-place update, and the
+   stateful resource is recreated (`MIGRATION.md` §stack names, proven in
+   `test/proof/migration-continuity.sh`, warned in `docs/content/workshops/v3-pipeline/06-*.md`). Record
+   replacement-triggering properties in a comment **where someone would edit them**, not in a doc.
+2. **Name, title and description limits come from the reference, not from a guess.** Charsets and
+   lengths, looked up. An EC2 description field allows only `a-zA-Z0-9`, spaces and
+   `._-:/()#,@[]+=;{}!$*` — an apostrophe in a possessive fails the deploy *after* CloudFormation has
+   started creating. Assume the toolchain will not catch it: this repo runs no `cdk synth --strict`
+   (`--strict` here is only `jsii-rosetta` and `mkdocs build`), so there is no synth-time net at all.
+   Where an error message and the property reference disagree on allowed characters, take the narrower
+   set.
+3. **Private by default, always.** Public access is never the default and never the convenient
+   shortcut. When something is unreachable the answer is the private path — a VPC/interface endpoint
+   plus an in-VPC client — not flipping a `public*` flag. Trading the network layer for IAM-only
+   protection is a posture decision that belongs to a human. If you believe public access is genuinely
+   required, **say so and stop**: don't implement it, and above all don't write a test that pins it — a
+   test asserts the decision is settled, which claims authority you weren't given.
+4. **No partial patching.** Fix the class in the construct, never the instance that happened to fail.
+   One bad character is a symptom; the defect is patching a constraint without checking its siblings.
+   Where a constraint covers a family of fields, assert it over the family — and make the assertion
+   **fail on an empty set**, because a scan that inspected nothing reports clean. Hand-fixing deployed
+   state is acceptable only against a full blocker (the IaC genuinely cannot express it), and then the
+   blocker is written down as a parameter plus a documented human step, never left as tribal knowledge.
+
 ## Task board
 
 `task.md` (repo root) is the living, schema-driven board of planned work, governed by
@@ -95,28 +128,52 @@ holds incidental discoveries.
 
 ## Toolchain (read this first)
 
-`node`/`yarn`/`npx` are **not on the default PATH**. Either enter `devbox shell`, or prepend:
+`node`/`yarn`/`npx` are **not on the default PATH**. Either enter `devbox shell`, or prepend a node bin
+dir **after checking it exists on this machine** — the dir is per machine and per user, so never paste
+one from another checkout or another session's notes:
 
 ```bash
-export PATH=/home/gyalai/.nvm/versions/node/v24.19.0/bin:$PATH   # node v24.19.0, yarn 1.22.22
-export NODE_OPTIONS=--max-old-space-size=6144                    # jsii compile needs the headroom
+# Prefer the node major CI builds on; fall back to the newest installed. Run from the repo root.
+CI_MAJOR=$(grep -ho 'node-version: *"[0-9]*"' .github/workflows/*.yml | grep -o '[0-9]\+' | sort -n | tail -1)
+NODE_BIN=$(ls -d "${NVM_DIR:-$HOME/.nvm}"/versions/node/v${CI_MAJOR:-*}.*/bin 2>/dev/null | sort -V | tail -1)
+[ -x "$NODE_BIN/node" ] || NODE_BIN=$(ls -d "${NVM_DIR:-$HOME/.nvm}"/versions/node/*/bin 2>/dev/null | sort -V | tail -1)
+[ -x "$NODE_BIN/node" ] && export PATH="$NODE_BIN:$PATH" || echo 'no nvm node found — use devbox shell'
+export NODE_OPTIONS=--max-old-space-size=6144   # jsii compile needs the headroom
 ```
 
-Yarn 1 workspaces over three packages in `packages/@cdklabs/`:
+The `SessionStart` hook (`.claude/hooks/preflight-toolchain.sh`) runs this check for you and reports
+which of `node`/`yarn`/`jq`/`python3` resolve, plus a verified dir to prepend.
+
+**Mind which node you get.** `.github/workflows/*.yml` build on node `24` and `lts/*`; `devbox.json`
+pins `nodejs@18.19.1`, behind both — devbox is the reliable way to get `task` and `jq`, not a match for
+CI's node. The preflight reads the pinned major out of the workflows and prefers a matching installed
+node, saying so; when nothing matches it names what it found and flags that a local-only pass on
+another major is weaker evidence than a CI run.
+
+**Never put `PATH` in `.claude/settings.json` under `env`.** Values there are **not** interpolated —
+`${PATH}` and `$PATH` arrive verbatim — so the entry *replaces* the session PATH instead of extending
+it. A stale entry there (a hardcoded nvm dir from another machine) left every session with a PATH of
+two non-existent directories, and every hook that resolves a binary by name died with exit 127
+(`/bin/sh: bash: command not found`, `/bin/sh: python3: command not found`) on every prompt and every
+tool call. PATH belongs in the shell you run commands in, not in committed settings.
+
+Yarn 1 workspaces over two packages in `packages/@cdklabs/`:
 
 | Package | Notes |
 |---|---|
 | `cdk-cicd-wrapper` | the constructs library — **jsii**, published to npm/PyPI/Maven/NuGet |
 | `cdk-cicd-wrapper-cli` | the `cdk-cicd` CLI (`bin/cdk-cicd`), plain TS |
-| `cdk-cicd-wrapper-projen` | projen project types, plain TS |
+
+`cdk-cicd-wrapper-projen` was the third package; v3 removed it (task.md **D5**, package consolidation
+3→2). Its migration path is `cicd.config.ts` + the `cdk-cicd` CLI — see `MIGRATION.md`.
 
 ## This repo is projen-managed
 
 **Never hand-edit generated files.** Anything containing `~~ Generated by projen` is output, not
 source — that includes every `package.json`, `tsconfig*.json`, `.eslintrc.json`, `.github/workflows/*`.
 
-Source of truth is `.projenrc.ts` + `projenrc/*.ts` (`RootConfig`, `PipelineConfig`, `CLIConfig`,
-`ProjenConfig`). Change those, then regenerate:
+Source of truth is `.projenrc.ts` + `projenrc/*.ts` (`RootConfig`, `PipelineConfig`, `CLIConfig` — the
+three `.projenrc.ts` instantiates). Change those, then regenerate:
 
 ```bash
 npx projen          # regenerate; must be re-run after touching .projenrc.ts or projenrc/

--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@
 </p>
 
 > [!WARNING]
-> **Experimental — pre-release (v3 `alpha`).** The public API is not yet frozen and may change
-> before the `1.0` release. The versions published to npm today are the stable `0.x` (v2) line;
-> the v3 developer experience described on the `v3` branch is under active development.
+> **Experimental — pre-release (`1.x` alpha), not yet published.** The developer experience
+> documented below is the Autopilot (`1.x`) line, which lives on `main` and has **no release yet** —
+> the newest published version is `0.3.9`, on the stable `0.x` (Blueprint) line. So `npm install`
+> today gives you `0.x`, whose API is *not* the one described here: see the
+> [Blueprint (0.x) documentation](https://cdklabs.github.io/cdk-cicd-wrapper/legacy/) for that, and
+> the [Migration Guide](./MIGRATION.md) for the mapping between the two. To try the flow below now,
+> work from this repository — `samples/cdk-v3-example/` is a complete example. The public API is not
+> frozen and may change before `1.0`.
 
 # Welcome to the CDK CI/CD Wrapper
 
@@ -65,7 +70,11 @@ To set up the CI/CD pipeline in your existing AWS CDK project, follow these step
 
 ### 1. Installation
 
-Install the CDK CI/CD Wrapper pipeline package by running the following command:
+> [!IMPORTANT]
+> As noted above, the `1.x` line these steps describe is **unreleased**, so the command below
+> currently resolves to `0.3.9` on the `0.x` line — which does not have `defineCICD` or
+> `cdk-cicd exec`. Until the first `1.x` alpha is published, follow these steps against a checkout of
+> this repository (start from `samples/cdk-v3-example/`) rather than a fresh `npm install`.
 
 ```bash
 npm i @cdklabs/cdk-cicd-wrapper @cdklabs/cdk-cicd-wrapper-cli
@@ -234,7 +243,7 @@ On top of that the CDK CI/CD Wrapper has arbitrary scripts that can be leveraged
 You should not fork this repository and expect to reproduce the same in your AWS Accounts, this repository is only used for preparing, testing and shipping all the packages used by the CDK CI/CD Wrapper. Using the CDK CI/CD Wrapper gives you the following benefits:
 
 - :white_check_mark: FOSS (Free and open-source software) scanning – built-in checks against a pre-defined adjustable list of licenses
-- :white_check_mark: Workbench – isolated test environment for developers which enables parallel testing in the same AWS Account without collisions
+- :white_check_mark: Workbench – isolated test environment for developers which enables parallel testing in the same AWS Account without collisions (`0.x` only; `1.x` has no pipeline equivalent — use a direct `cdk deploy`, see [MIGRATION.md](./MIGRATION.md))
 - :white_check_mark: Automated security scanners – enabled by default bandit, shellcheck, npm audit, pip audit, etc)
 - :white_check_mark: AWS CDK Language agnostic – support for TypeScript and Python, on the works to fully support Java / C# / Go 
 - :white_check_mark: Built for many project types - facilitating MLOps usecase, Web App development (UIs), GenAI usecases

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ This repository is organized as a monorepo containing multiple packages and tool
 
 ### Core Packages
 
-- **`packages/@cdklabs/cdk-cicd-wrapper`** - Main CDK constructs and pipeline blueprint library containing:
-  - **Pipeline Stacks** - Core infrastructure components (EncryptionStack, PipelineStack, WorkbenchStack)
-  - **Repository Stacks** - Version control integration (CodeCommitRepositoryStack, CodeStarConnectRepositoryStack, S3RepositoryStack)
-  - **Supporting Stacks** - Additional infrastructure (SSMParameterStack, PostDeployExecutorStack, ComplianceBucketStack)
-  - **VPC Stacks** - Network configuration options (ManagedVPCStack, NoVPCStack, VPCFromLookUpStack)
-- **`packages/@cdklabs/cdk-cicd-wrapper-cli`** - Command-line interface for validation, security scanning, and project management
+- **`packages/@cdklabs/cdk-cicd-wrapper`** - CDK constructs library (jsii — published to npm, PyPI, Maven and NuGet), containing:
+  - **Config authoring** - the `cicd.config.ts` surface: `defineCICD`, `Repository`, `AppConfig`
+  - **Engines** - what renders the pipeline: `CodePipelineEngine`, `CdkPipelinesEngine`, `GitHubActionsEngine`
+  - **Runtime injection** - `CdkCicd.attach` for explicit opt-in, plus the preload that `cdk-cicd exec` uses to wrap a plain CDK app at synth time
+  - **Support resources** - `SupportResources` (lazily provisioned), VPC networking for the pipeline's own CodeBuild projects, log retention, and the default-on security-hardening aspects
+- **`packages/@cdklabs/cdk-cicd-wrapper-cli`** - the `cdk-cicd` CLI: `deploy-ci`, `exec`, `synth`, `check` and `migrate`, plus `validate`, `license`, `security-scan` and `check-dependencies`
 
 ### Additional Components
 
@@ -71,52 +71,55 @@ Install the CDK CI/CD Wrapper pipeline package by running the following command:
 npm i @cdklabs/cdk-cicd-wrapper @cdklabs/cdk-cicd-wrapper-cli
 ```
 
-### 2. Basic Setup
+### 2. Describe the pipeline in `cicd.config.ts`
 
-Open your entry file, typically located at `bin/<your-main-file>.ts` (where `your-main-file` is the name of your root project directory).
-
-Include the `PipelineBlueprint.builder().synth(app)` statement in your entry file:
+Create `cicd.config.ts` next to your `cdk.json`. This is the only file the wrapper needs:
 
 ```typescript
-import * as cdk from 'aws-cdk-lib';
-import { PipelineBlueprint } from '@cdklabs/cdk-cicd-wrapper';
+import { defineCICD, Repository } from '@cdklabs/cdk-cicd-wrapper';
 
-const app = new cdk.App();
-
-PipelineBlueprint.builder().synth(app);
+export default defineCICD({
+  application: 'my-project',
+  repository: Repository.codecommit('my-project'), // or Repository.s3(...), or Repository.codestarConnection(...) for GitHub
+  // 'dev' auto-approves (inner loop); 'prod' is gated by a manual approval by default.
+  stages: ['dev', { name: 'prod', env: { account: '111111111111', region: 'eu-west-1' } }],
+});
 ```
 
-This will deploy the CI/CD pipeline with its default configuration without deploying any stacks into the staging accounts.
+### 3. Point `cdk.json` at `cdk-cicd exec`
 
-### 3. Adding Your Application Stacks (Optional)
+**There is no wrapper code in your app.** Your `bin/` entry point stays exactly what `cdk init` produced; `cdk.json`'s `app` command is what wraps it:
 
-If you want to include additional stacks in the CI/CD pipeline, modify your entry file as follows:
+```json
+{
+  "app": "npx cdk-cicd exec bin/my-project.ts"
+}
+```
+
+`cdk-cicd exec` resolves the active stage's config, exports its account/region so a stock `env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION }` resolves correctly, and runs your entry file under a preload that applies the wrapper's runtime hooks (tagging, default security aspects). Add application stacks to the plain `App` as you normally would — no provider registry, no wrapper imports:
 
 ```typescript
+// bin/my-project.ts — ordinary CDK
 import * as cdk from 'aws-cdk-lib';
-import { PipelineBlueprint, GlobalResources } from '@cdklabs/cdk-cicd-wrapper';
+import { MyStack } from '../lib/my-stack';
 
 const app = new cdk.App();
-
-PipelineBlueprint.builder().addStack({
-provide: (context) => {
-   // Create your stacks here
-   new YourStack(context.scope, `${context.blueprintProps.applicationName}YourStack`, {
-      applicationName: context.blueprintProps.applicationName,
-      stageName: context.stage,
-   });
-   new YourOtherStack(context.scope, `${context.blueprintProps.applicationName}YourOtherStack`, {
-      applicationQualifier: context.blueprintProps.applicationQualifier,
-      encryptionKey: context.get(GlobalResources.ENCRYPTION)!.kmsKey,
-   });
-}}).synth(app);
+new MyStack(app, 'my-project', {
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+});
 ```
 
-**Note**: Refer to the [Developer Guide](https://cdklabs.github.io/cdk-cicd-wrapper/developer_guides/index.html) for more information on the `PipelineBlueprint`.
+**Optional**: use the `stageStackName` helper to control the CloudFormation stack name per stage (`my-project-dev`/`my-project-prod`). Migrating from a previous major? Matching the old stack name is what makes the migration an in-place update instead of a resource replacement — see the [Migration Guide](./MIGRATION.md).
 
-### 4. Required Scripts Configuration
+`samples/cdk-v3-example/` is this exact shape as a working project. For a non-Node app entry (for example Python), the preload cannot attach, so use the explicit `CdkCicd.attach(app)` call instead.
 
-The CDK CI/CD Wrapper expects to have the `validate`, `lint`, `test`, `audit` scripts defined. If you are missing any of the `npm run` scripts, or want to use the provided CLI tool for one or more actions, you can add the following definitions to your `package.json` file:
+**Note**: Refer to the [Getting Started guide](https://cdklabs.github.io/cdk-cicd-wrapper/getting_started/index.html) for the full stage shape, repository sources, and CI configuration.
+
+### 4. Optional Scripts Configuration
+
+By default the pipeline's build step runs `npx cdk-cicd check`, which covers `validate` (lock-file integrity), `audit` (dependency CVEs), `license` (open-source license checking) and `security` (Bandit/Semgrep/ShellCheck) — each **skipped rather than failed** when your project has no baseline for it yet. You do not need to define any scripts to get started.
+
+Setting `ci.steps` in `cicd.config.ts` *replaces* that default rather than adding to it, so include `check` explicitly if you still want those checks alongside your own `build`/`test`. If you would rather drive the same checks from `package.json`, add the definitions below:
 
 #### 4.1. Adding validate script
 ```bash
@@ -184,46 +187,30 @@ npm run audit:fix:license
 - `npm run validate:fix` will create the required `package-verification.json` file for you.
 - `npm run audit:fix:license` will generate a valid Notice file for you.
 
-### 6. Deploy the CI/CD Pipeline
+### 6. Bootstrap and deploy the CI/CD Pipeline
 
-Deploy all the stacks by running the following command:
+Bootstrap every account/region a stage targets, trusting the account the pipeline itself runs in:
 
 ```bash
-npx dotenv-cli -- npm run cdk deploy -- --all --region ${AWS_REGION} --profile $RES_ACCOUNT_AWS_PROFILE --qualifier ${CDK_QUALIFIER}
+npx cdk bootstrap aws://<STAGE_ACCOUNT>/<STAGE_REGION> --trust <PIPELINE_ACCOUNT> \
+  --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess
 ```
 
-Once the command finishes, the following CDK Stacks will be deployed into your RES Account:
+Then, from the account and region the pipeline should run in:
 
-#### Core Infrastructure Stacks
+```bash
+npx cdk-cicd deploy-ci
+```
 
-- **EncryptionStack**: Creates and manages KMS keys for encrypting CloudWatch Log Groups and other AWS resources. Features automatic key rotation and proper service principal permissions.
+This provisions the pipeline from `cicd.config.ts` alone — nothing else needs to exist yet. From there the pipeline **self-updates from `cicd.config.ts` on every run**, so `deploy-ci` is a one-time manual command (and again only if you need to recover a deleted pipeline stack).
 
-- **PipelineStack**: The main orchestration stack that creates the CodePipeline with all CodeBuild steps, manages deployment stages, and coordinates the entire CI/CD workflow.
+#### What the pipeline does
 
-- **SSMParameterStack**: Creates and manages parameters in AWS Systems Manager Parameter Store, including account IDs, configuration values, and cross-stage references.
+**Source** → **Build** (`npm ci`, then your `ci.steps` or the default `npx cdk-cicd check`, then `cdk synth` with CDK Nag) → **self-update** → one **deploy** action per configured stage, in order, each gated by a manual approval except your inner-loop stages (`dev`/`res`) unless you set `manualApproval` explicitly.
 
-#### Repository Integration Stacks (One of the following based on your configuration)
+Supporting resources — the encryption key, VPC networking for the pipeline's own CodeBuild projects, a compliance bucket — are **lazily provisioned**, so a pipeline only pays for what its configuration actually references.
 
-- **CodeCommitRepositoryStack**: Sets up AWS CodeCommit repository with automated pull request workflows, CodeGuru scanning integration, and branch protection rules.
-
-- **CodeStarConnectRepositoryStack**: Establishes secure connection between your AWS RES Account and external Git repositories (GitHub, Bitbucket, etc.) via AWS CodeStar connections.
-
-- **S3RepositoryStack**: Configures S3-based artifact storage for scenarios where direct repository integration isn't suitable.
-
-#### Optional Infrastructure Stacks
-
-- **VPC Stacks** (deployed based on your networking configuration):
-  - **ManagedVPCStack**: Creates a fully managed VPC with subnets, NAT gateways, and routing for isolated pipeline execution
-  - **VPCFromLookUpStack**: Uses existing VPC infrastructure by looking up VPC resources in your account
-  - **NoVPCStack**: Default configuration for pipelines that don't require VPC isolation
-
-- **WorkbenchStack**: Provides isolated development and testing environment that allows developers to deploy and test stacks independently from the main CI/CD pipeline.
-
-- **PostDeployExecutorStack**: Handles post-deployment actions such as integration tests, notifications, and cleanup tasks.
-
-- **ComplianceBucketStack**: Creates S3 buckets and Lambda functions for compliance logging and audit trail management.
-
-**Note**: VPC stacks are only created when specifically configured. Check the [networking documentation](https://cdklabs.github.io/cdk-cicd-wrapper/developer_guides/networking.html) for more information on networking configurations.
+**Note**: Check the [networking documentation](https://cdklabs.github.io/cdk-cicd-wrapper/developer_guides/networking.html) for VPC configurations, and the [Migration Guide](./MIGRATION.md) if you are coming from the previous major, where the pipeline was assembled from a set of named stacks in your own `bin/`.
 
 Visit our [documentation](https://cdklabs.github.io/cdk-cicd-wrapper/) to learn more.
 

--- a/test/proof/migration-continuity.sh
+++ b/test/proof/migration-continuity.sh
@@ -3,10 +3,31 @@
 # in-place UPDATE (stateful resource PRESERVED); a mismatched name is a new stack (resource RECREATED).
 # Uses the real stageStackName helper to generate the names. Sandbox only; every stack is cdkcicdtest-
 # prefixed + tagged and torn down. No account id is printed.
+# Deliberately does NOT source harness.sh: that file sets `-e` at file scope, and the verdict
+# comparisons plus the `phys`/`status` helpers below need non-zero exits to stay survivable. It mirrors
+# the harness's pattern instead -- git-derived repo root, CDK_CICD_REPO_ROOT/CDK_CICD_ENV_FILE
+# overrides, guarded .env.
 set -uo pipefail
-export PATH=/home/gyalai/.nvm/versions/node/v24.19.0/bin:/usr/bin:/bin:$PATH
-cd /home/gyalai/.workspace/src/cdk-cicd-wrapper; set -a; . ./.env; set +a
-R=us-west-2; RUN="r$(date -u +%Y%m%d%H%M%S)"; TAG="cdk-cicd-wrapper-test"
+
+# Test the toolchain before using it; PATH belongs to the invoking shell, never to this script (see
+# CLAUDE.md -> Toolchain). A hardcoded nvm dir here made the script unrunnable on any other machine.
+for tool in git node aws; do
+  command -v "$tool" >/dev/null 2>&1 || { printf 'FAIL: %s is not on PATH -- see CLAUDE.md -> Toolchain\n' "$tool" >&2; exit 1; }
+done
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CDK_CICD_REPO_ROOT:-$(git -C "$HERE" rev-parse --show-toplevel)}"
+cd "$REPO_ROOT" || { printf 'FAIL: cannot cd to repo root %s\n' "$REPO_ROOT" >&2; exit 1; }
+
+ENV_FILE="${CDK_CICD_ENV_FILE:-$REPO_ROOT/.env}"
+[ -f "$ENV_FILE" ] || { printf 'FAIL: no env file at %s (see CLAUDE.md -> AWS / test account)\n' "$ENV_FILE" >&2; exit 1; }
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+[ -n "${CDK_CICD_TEST_ACCOUNT:-}" ] || { printf 'FAIL: CDK_CICD_TEST_ACCOUNT is unset\n' >&2; exit 1; }
+
+R="${CDK_CICD_TEST_REGION_PRIMARY:-us-west-2}"; RUN="r$(date -u +%Y%m%d%H%M%S)"; TAG="cdk-cicd-wrapper-test"
 redact(){ sed -E "s/${CDK_CICD_TEST_ACCOUNT}/<account>/g"; }
 NAMING=./packages/@cdklabs/cdk-cicd-wrapper/lib/v3/config/naming.js
 
@@ -16,7 +37,10 @@ V3NAME=$(CDK_STAGE=dev node -e "console.log(require('$NAMING').stageStackName('c
 echo "v2-match name : $V2NAME"
 echo "v3-default name: $V3NAME"
 
-TA=$(mktemp --suffix=.json); TB=$(mktemp --suffix=.json)
+# Scratch stays in the repo's .gitignored .tmp/ -- `mktemp --suffix` is GNU-only (fails on macOS) and
+# system temp is refused by the tmp-confinement guard in .claude/hooks/.
+SCRATCH="$REPO_ROOT/.tmp"; mkdir -p "$SCRATCH"
+TA="$SCRATCH/mig-$RUN-a.json"; TB="$SCRATCH/mig-$RUN-b.json"
 echo '{"Resources":{"Data":{"Type":"AWS::S3::Bucket","Properties":{}}}}' > "$TA"
 echo '{"Resources":{"Data":{"Type":"AWS::S3::Bucket","Properties":{}},"Marker":{"Type":"AWS::SSM::Parameter","Properties":{"Type":"String","Value":"migrated"}}}}' > "$TB"
 


### PR DESCRIPTION
## Description

Fixes # <!-- no issue; found while debugging hook failures in a local session -->

`.claude/settings.json` pinned `env.PATH` to a hardcoded nvm bin dir from another machine. Claude Code does **not** interpolate `${PATH}`/`$PATH` in `env` — the value arrives verbatim — so that entry *replaced* the session PATH with two non-existent directories rather than extending it. Every hook that resolves an executable by name then failed with exit 127 on every prompt and every tool call:

```
UserPromptSubmit hook error: /bin/sh: python3: command not found
PreToolUse:Bash   hook error: /bin/sh: bash: command not found
```

Even `/bin/bash` was unresolvable, which is the tell that PATH itself was the fault rather than any individual hook. Chasing it surfaced the same hardcoded-path defect in `test/proof/migration-continuity.sh`, plus stale claims in `CLAUDE.md` left over from `f152318`.

## Changes

- **`fix(agent)`** — drop the `env.PATH` override (keep `NODE_OPTIONS`, `GIT_PAGER`); invoke both hooks via an absolute `/bin/bash` so a clobbered PATH can't 127 them; add a `SessionStart` preflight that reports which of `node`/`yarn`/`jq`/`python3` resolve and names a node bin dir **only after confirming it exists and holds an executable node**, preferring the major CI builds on (read out of `.github/workflows/*.yml`) and falling back to newest. It uses only shell builtins — a preflight that shells out to coreutils can't report that coreutils is unreachable. Also gives the tmp-confinement guard a `jq` preflight, so a missing `jq` yields one clear "guard is OFF" message instead of failing open silently on every call.
- **`chore(schemas)`** — retire the `projen` value from the `component` axis in `findings.schema.json` and `tasks.schema.json`. v3 removed `@cdklabs/cdk-cicd-wrapper-projen` (task.md **D5**, consolidation 3→2); **0 of 110** findings and 0 tasks used the value, so this narrowing invalidates nothing.
- **`fix(proof)`** — `migration-continuity.sh` hardcoded `export PATH=/home/<user>/.nvm/…` and `cd /home/<user>/.workspace/…`, so it could not run anywhere but its author's box. Now mirrors `harness.sh`'s pattern (git-derived repo root, `CDK_CICD_REPO_ROOT`/`CDK_CICD_ENV_FILE` overrides, guarded `.env`). It deliberately does **not** source `harness.sh`, whe — this script needs non-zero exits to stay survivable inits `phys`/`status` helpers and verdict comparisons. Adds a `node`/`aws`/`git` preflight and moves scratch into the gitignored `.tmp/`, since `mktemp--suffix` is GNU-only and system temp is refused by the tmp-c
- **`docs(claude)`** — drift trueup, each claim re-derived from the repo: "three packages" → **two** (the table still listed the deleted projen      package); dropped `ProjenConfig` from the projenrc list (`protConfig`, `PipelineConfig`, `CLIConfig`, which is what`.projenrc.ts` instantiates — `ProjenConfig` never existed); replaced the hardcoded nvm path with a snippet that checks the dir exists; recorded thatworkflows build on node `24`/`lts/*` while `devbox.json` pins**Writing CDK resources** section: update/replacementsemantics recorded where someone would edit them, name/description limits taken from the reference rather than guessed, private by default with no   test pinning a public posture, and no partial patching.
                                                                                                                                                     No library source is touched — this is agent configuration, d
                                                                                                                                                     ## Testing
                                                                                                                                                     - [ ] Unit tests pass (`npm run test`)
- [ ] Built locally (`npm run build`)                                                                                                                
**Neither ran, and CI is the first real check.** `node_modules` is absent in the environment this was authored in, and `core.hooksPath` is set to an external hooks dir, so `.husky` never fires — `lint`, `valida`, `build` and `license` were all silently skipped rather than gated. Flagging that explicitly instead of ticking boxes.

What *was* verified:

- `node tools/scrub-check.js` → `scrub-check OK: no internal references or non-placeholder account ids found.` (run directly, since `npm run
scrub-check` needs deps)
- Added-line scan for absolute home paths and personal identity → none
- Hook suite re-run under a healthy PATH, the exact broken PA, valid JSON, no stderr in all three; previously exit 127
- Two real sessions in the repo → **0** `hook_non_blocking_error` (the failing session had 6); `python3`/`bash`/`jq` all resolve; the `SessionStart` preflight fires as `hook_success` and injects its context
- Guard still blocks: `touch /tmp/…` denied end-to-end and the file not created; `/tmp` write, `> /tmp`, bare `mktemp` denied; repo `.tmp/` write and
`cat /tmp` allowed
- Guard with `jq` unreachable → exit 0 plus a valid `systemMessage`, not 127
- Node-major preference: with v20/v22/v24/v26 installed it sejor), and warns when no installed node matches
- `bash -n` clean on both hooks and the proof script; shellcheck clean; all three JSON files parse; 110/110 findings satisfy the narrowed enum
- The `CLAUDE.md` snippet run verbatim → resolves node v24.5.prints the devbox fallback

## Checklist

- [x] Conventional-commit title (`feat:`/`fix:`/`chore:`/`ref
- [x] Breaking changes flagged with `feat!:` or a `BREAKING CHANGE:` footer — n/a, no breaking changes; the schema enum narrowing is unused (0/110)
- [x] Docs updated if behaviour changed

By submitting this pull request, I confirm that my contributi of the Apache-2.0 license.