### PR TITLE
fix: restore npm latest to the 0.x Blueprint line

### DIFF
--- a/packages/@cdklabs/cdk-cicd-wrapper-cli/src/index.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper-cli/src/index.ts
@@ -3,6 +3,10 @@
 
 /* eslint-disable no-console */
 
+// This package tracks the 0.x (PipelineBlueprint) maintenance line, published from the
+// `legacy-blueprint` branch under the npm `latest` dist-tag. The v3 rewrite develops
+// separately and publishes under the `next` dist-tag until it reaches 1.0.0.
+
 import * as yargs from 'yargs';
 import checkDependencies from './cmds/CheckDependenciesCommand';
 import complianceBucket from './cmds/ComplianceBucketCommand';

--- a/packages/@cdklabs/cdk-cicd-wrapper/README.md
+++ b/packages/@cdklabs/cdk-cicd-wrapper/README.md
@@ -4,6 +4,12 @@
 
 The [CDK CI/CD Wrapper](https://cdklabs.github.io/cdk-cicd-wrapper/) is a comprehensive solution that streamlines the delivery of your AWS Cloud Development Kit (CDK) applications. It provides a robust and standardized multi-stage CI/CD pipeline, ensuring high quality and confidence throughout the development and deployment process.
 
+> **Note:** This is the actively maintained **0.x (`PipelineBlueprint`) line**, published from the
+> `legacy-blueprint` branch under the npm `latest` dist-tag — `npm install @cdklabs/cdk-cicd-wrapper`
+> without a version pin continues to resolve here. A ground-up v3 rewrite is developed separately and
+> publishes under the `next` dist-tag until it reaches 1.0.0; the docs site linked above tracks v3, not
+> this package version.
+
 ## Table of Contents
 
 - [Introduction](#introduction)
@@ -59,7 +65,7 @@ For developing Python Lambdas, you'll also need:
 1. Clone the CDK CI/CD Wrapper repository:
 
    ```bash
-   git clone https://github.com/your-repo/cdk-cicd-wrapper.git
+   git clone https://github.com/cdklabs/cdk-cicd-wrapper.git
    cd cdk-cicd-wrapper
    ```
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/index.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/index.ts
@@ -3,6 +3,10 @@
 
 /**
  * This file exports various modules from other files within the project.
+ *
+ * This package tracks the 0.x (PipelineBlueprint) maintenance line, published from the
+ * `legacy-blueprint` branch under the npm `latest` dist-tag. The v3 rewrite develops
+ * separately and publishes under the `next` dist-tag until it reaches 1.0.0.
  */
 
 // Exporting all exports from the './common' file


### PR DESCRIPTION
## Summary
- `main` accidentally merged the `v3` branch (#223) and published it as `0.4.0` under npm's `latest` dist-tag, breaking unpinned installs of the 0.x `PipelineBlueprint` line.
- Releasing from `legacy-blueprint` (majorVersion pinned to 0, dist-tag `latest`) restores `latest` to the correct 0.x content — computes to `0.4.1`.
- Also bumps `@cdklabs/cdk-cicd-wrapper-cli` alongside it, fixes a stale placeholder clone URL in the wrapper README, and adds a short in-code/README note on both packages clarifying this is the 0.x maintenance line, separate from v3.

## Test plan
- [x] `npx projen compile` clean on both `cdk-cicd-wrapper` and `cdk-cicd-wrapper-cli`
- [x] `eslint` clean on both touched entrypoints
- [ ] Merge triggers `release-legacy-blueprint.yml` — confirm it publishes `0.4.1` under `latest` on npm