### PR TITLE
fix: restore npm latest to the 0.x Blueprint line (again)

### DIFF
--- a/packages/@cdklabs/cdk-cicd-wrapper-cli/src/index.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper-cli/src/index.ts
@@ -6,6 +6,10 @@
 // This package tracks the 0.x (PipelineBlueprint) maintenance line, published from the
 // `legacy-blueprint` branch under the npm `latest` dist-tag. The v3 rewrite develops
 // separately and publishes under the `next` dist-tag until it reaches 1.0.0.
+//
+// main still auto-publishes under this same 0.x/latest line on every releasable commit (see
+// task.md D6), so it will keep overwriting latest with v3 content until main's release config
+// is split onto its own major version. Releasing again from here is a recurring stopgap.
 
 import * as yargs from 'yargs';
 import checkDependencies from './cmds/CheckDependenciesCommand';

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/index.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/index.ts
@@ -7,6 +7,11 @@
  * This package tracks the 0.x (PipelineBlueprint) maintenance line, published from the
  * `legacy-blueprint` branch under the npm `latest` dist-tag. The v3 rewrite develops
  * separately and publishes under the `next` dist-tag until it reaches 1.0.0.
+ *
+ * `main` still auto-publishes under the same 0.x/`latest` line on every releasable commit
+ * (see task.md D6), so it will keep overwriting `latest` with v3 content until main's own
+ * release config is split onto its own major version. Releasing again from this branch is a
+ * recurring stopgap, not a one-time fix.
  */
 
 // Exporting all exports from the './common' file


### PR DESCRIPTION
## Summary
- `main` merged another releasable commit (#224) on top of the earlier v3 merge; main's still-active 0.x release config republished v3 content as `0.4.2`/`0.3.2` under npm `latest` for both packages.
- Same remedy as #226: a releasable `fix:` commit on `legacy-blueprint` republishes the correct Blueprint content under `latest`. Both infra blockers from last time (environment branch policy, npm Trusted Publisher workflow-filename match) are already fixed, so this should publish cleanly without extra intervention.

## This will keep happening
`main`'s release config is still wired to publish under the 0.x/`latest` line (task.md D6 — splitting main onto its own major version is staged but on hold pending a maintainer decision). Every future releasable commit merged to `main` will repeat this exact incident. Re-releasing from `legacy-blueprint` is a stopgap per occurrence, not a fix for the recurrence itself.

## Test plan
- [x] `eslint` clean on both touched entrypoints
- [ ] Merge, confirm `release.yml` (legacy-blueprint's, shared filename) publishes `0.4.3`/`0.3.3` under `latest` on npm