### PR TITLE
chore: add container-mode guide and fix stale approval-gate note

### DIFF
--- a/docs/content/developer_guides/.pages.yml
+++ b/docs/content/developer_guides/.pages.yml
@@ -1,19 +1,20 @@
 ---
 nav:
   - index.md
-  - "Continuous Integration": "ci.md"
-  - "Continuous Deployment": "cd.md"
-  - "CDK Context": "cdk_context.md"
-  - "Security": "security.md"
-  - "Python Dependencies":
-    - "AWS CodeArtifact": "codeartifact.md"
-    - "python_dependencies.md"
-  - "NPM Dependencies":
-    - "AWS CodeArtifact": "codeartifact.md"
-    - "Private NPM Registry": "private_npm_registry.md"
-  - "GIT Integrations":
-    - "Amazon S3": "vcs_s3.md"
-    - "CodeCommit": "vcs_codecommit.md"
-    - "GitHub": "vcs_github.md"
-  - "Networking": "networking.md"
-  - "Git Branching Strategies": "gitbranchingstrategies.md"
+  - 'Continuous Integration': 'ci.md'
+  - 'Continuous Deployment': 'cd.md'
+  - 'Container Mode': 'container_mode.md'
+  - 'CDK Context': 'cdk_context.md'
+  - 'Security': 'security.md'
+  - 'Python Dependencies':
+      - 'AWS CodeArtifact': 'codeartifact.md'
+      - 'python_dependencies.md'
+  - 'NPM Dependencies':
+      - 'AWS CodeArtifact': 'codeartifact.md'
+      - 'Private NPM Registry': 'private_npm_registry.md'
+  - 'GIT Integrations':
+      - 'Amazon S3': 'vcs_s3.md'
+      - 'CodeCommit': 'vcs_codecommit.md'
+      - 'GitHub': 'vcs_github.md'
+  - 'Networking': 'networking.md'
+  - 'Git Branching Strategies': 'gitbranchingstrategies.md'

--- a/docs/content/developer_guides/container_mode.md
+++ b/docs/content/developer_guides/container_mode.md
@@ -1,0 +1,135 @@
+# Container mode (two-repository Docker deploy)
+
+Container mode splits build from deploy into **two repositories**: a CI repository builds and pushes a
+config-agnostic **deployer image**, and a config-only CD repository runs that image against as many
+targets as you like. One image drives _N_ deployments, and rollback is a retag.
+
+!!! info "Engine support"
+Container mode is a feature of the default **CodePipeline engine** (`EngineType.CODEPIPELINE`). The
+`CDK_PIPELINES` and `GitHubActions` engines deploy stages directly by replaying the app per stage;
+they do not build or consume a deployer image.
+
+## When to use it
+
+Reach for container mode when you want to build the deployable artifact **once** and promote that exact
+artifact through stages — including across repositories or teams — rather than re-synthesizing per stage
+from source. Because the image bakes the CDK app and its npm dependencies, the CD side needs no source,
+no `npm install`, and no registry access at deploy time: it can synth-and-deploy **offline** against each
+target's configuration.
+
+## Repo 1 — build the deployer image
+
+The CI repository is your normal CDK app. Add a `deployerImage` to `cicd.config.ts` and the pipeline
+renders as `Source → BuildImage` with **no deploy stages** — it builds and pushes an image instead of
+deploying:
+
+```typescript
+import { defineCICD, Repository, BuildImage, ImageTagStrategy } from '@cdklabs/cdk-cicd-wrapper';
+
+export default defineCICD({
+  application: 'my-app',
+  repository: Repository.github('my-org/my-app'),
+  deployerImage: BuildImage.docker({
+    dockerfile: 'Dockerfile', // default; the image payload is your app + deps, NOT cdk.out
+    // repositoryName: 'my-app-deployer', // reference an existing ECR repo; omit to provision one
+    // tagStrategy: ImageTagStrategy.GIT_SHA, // default: tag by resolved commit; or ImageTagStrategy.LATEST
+  }),
+});
+```
+
+`cdk-cicd deploy-ci` provisions the CI pipeline. Its single build project:
+
+1. runs `npm ci` and `cdk-cicd check` (CI as a validation gate),
+2. logs in to ECR,
+3. `docker build`s your Dockerfile and pushes the image, tagged by strategy (`GIT_SHA` by default —
+   immutable; `LATEST` is simplest but not immutable).
+
+If you do not name an existing repository, the pipeline **provisions** one named `<application>-deployer`;
+a disposable pipeline (`deploy-ci --disposable`) empties and deletes it on teardown.
+
+### Why the image, not `cdk.out`
+
+The image bakes code + dependencies but **never** `cdk.out`, so the CD side can synth-and-deploy it
+offline against any target's config. That is what collapses per-target pipeline sprawl: targets become
+config rows a single image is run against, not pipeline resources.
+
+## Repo 2 — deploy the image
+
+The CD repository is a small, app-agnostic **config repository** (no CDK code). It declares **which
+image** to run and **where** to deploy it, via `defineDeployment` in a `deploy.config.ts`:
+
+```typescript
+// deploy.config.ts
+import { defineDeployment, Repository } from '@cdklabs/cdk-cicd-wrapper';
+
+export default defineDeployment({
+  // The BASE deployer image repository (no tag). The per-stage version is appended at deploy time.
+  image: '111111111111.dkr.ecr.eu-west-1.amazonaws.com/my-app-deployer',
+
+  // The config-only source repo this CD pipeline watches (deploy.config.ts + config/<stage>.json).
+  // Omit it to use only the local `cdk-cicd deploy --from-image` executor with no CD pipeline.
+  repository: Repository.codecommit('my-app-deploy-config'),
+
+  // Targets say WHERE (account/region/role) + gating. The VERSION each runs comes from config/<stage>.json.
+  targets: [
+    { stage: 'dev', env: { account: '111111111111', region: 'eu-west-1' } },
+    { stage: 'int', env: { account: '111111111111', region: 'eu-west-1' }, manualApproval: true },
+    {
+      stage: 'prod',
+      env: { account: '222222222222', regions: ['eu-west-1', 'us-east-1'] },
+      manualApproval: true,
+      deployment: { deployRole: 'arn:aws:iam::222222222222:role/automation-deployer' },
+    },
+  ],
+});
+```
+
+Each stage's **version lives in its own config file** in the CD repository (a hash or semver) — _not_
+baked in the image:
+
+```jsonc
+// config/dev.json          config/int.json           config/prod.json
+{ "version": "1.5.0" }      { "version": "1.4.2" }     { "version": "1.4.2" }
+```
+
+The deploy resolves `image = <base-repo>:<version from config/<stage>.json>`, so `dev` can run a newer
+version than `prod`, and the version is plain config, reviewable in a pull request.
+
+### Provision the CD pipeline, or run locally
+
+With a `repository` set, `cdk-cicd deploy-ci` provisions the CD pipeline (the deploy-side twin of the CI
+`deploy-ci`): a `Source` stage, then a `Deploy` stage with every **ungated** target running in parallel,
+then a `DeployGated` stage where each **gated** target sits behind its own manual-approval action. Each
+deploy action runs `cdk-cicd deploy --from-image --target <stage>`, which reads that stage's `version` at
+run time, pulls `<base-repo>:<version>`, and synth-and-deploys the stage.
+
+The same executor runs locally without any pipeline:
+
+```bash
+npx cdk-cicd deploy --from-image           # every target (gated targets require --yes)
+npx cdk-cicd deploy --from-image --target dev
+```
+
+On a runner whose default Docker network cannot reach AWS, add `--docker-network host`. The local
+executor is fail-closed: it refuses a target with `manualApproval: true` unless you pass `--yes`.
+
+## Division of authority: WHAT vs WHERE
+
+The **image** is authoritative for _what_ to deploy — the app code and its stage definitions are baked in
+at build time. The **`deploy.config.ts` target** is authoritative for _where_ — the account, region(s),
+and forced role for each stage. That is why each run pins a single `--region`: the target's environment
+overrides whatever region set the image's own `cicd.config.ts` carries, so the CD repository — not the
+image — decides the deployment topology.
+
+## Rollback is a retag
+
+To roll back, point a stage's version file at the previous tag (e.g. `config/prod.json`'s `version` back
+to `1.4.1`) and re-run. Because the image pins code + deps and config supplies the lookups, the same image
+
+- same config always synthesizes the same template — a deterministic rollback with no rebuild.
+
+## See also
+
+- [Continuous Deployment](./cd.md) — stages, approvals, and per-stage configuration.
+- The workshop module [Container mode: build once, deploy many](../workshops/autopilot-pipeline/05-container-mode.md)
+  walks the same flow end to end.

--- a/docs/content/workshops/autopilot-pipeline/05-container-mode.md
+++ b/docs/content/workshops/autopilot-pipeline/05-container-mode.md
@@ -1,11 +1,8 @@
 # Container mode: build once, deploy many
 
-!!! abstract "What you'll build"
-    - **Repo 1 — CI pipeline:** runs CI and pushes a config-agnostic deployer image to ECR — it deploys
-      nothing.
-    - **Repo 2 — CD pipeline:** a config-only `deploy.config.ts` whose pipeline pulls that image and
-      deploys each target (or run the same executor locally with `cdk-cicd deploy --from-image`).
-    - An understanding of the "one image → many deployments" scale-out and rollback-by-retag.
+!!! abstract "What you'll build" - **Repo 1 — CI pipeline:** runs CI and pushes a config-agnostic deployer image to ECR — it deploys
+nothing. - **Repo 2 — CD pipeline:** a config-only `deploy.config.ts` whose pipeline pulls that image and
+deploys each target (or run the same executor locally with `cdk-cicd deploy --from-image`). - An understanding of the "one image → many deployments" scale-out and rollback-by-retag.
 
 For an enterprise / "Automation Framework" flow, Autopilot supports a **two-repo split**:
 
@@ -27,7 +24,7 @@ export default defineCICD({
   application: 'my-app',
   repository: Repository.github('my-org/my-app'),
   deployerImage: BuildImage.docker({
-    dockerfile: 'Dockerfile',      // default; the image payload is your app + deps, NOT cdk.out
+    dockerfile: 'Dockerfile', // default; the image payload is your app + deps, NOT cdk.out
     // repositoryName: 'my-app-deployer',   // reference an existing ECR repo; omit to provision one
     // tagStrategy: ImageTagStrategy.GIT_SHA,  // default: tag by commit; or LATEST
   }),
@@ -72,15 +69,19 @@ export default defineDeployment({
 
   // Targets say WHERE (account/region/role) + gating. The VERSION each runs comes from config/<stage>.json.
   targets: [
-    { stage: 'dev',  env: { account: '111111111111', region: 'eu-west-1' } },
-    { stage: 'int',  env: { account: '111111111111', region: 'eu-west-1' }, manualApproval: true },
-    { stage: 'prod', env: { account: '222222222222', regions: ['eu-west-1', 'us-east-1'] },
-      manualApproval: true, deployment: { deployRole: 'arn:aws:iam::222222222222:role/automation-deployer' } },
+    { stage: 'dev', env: { account: '111111111111', region: 'eu-west-1' } },
+    { stage: 'int', env: { account: '111111111111', region: 'eu-west-1' }, manualApproval: true },
+    {
+      stage: 'prod',
+      env: { account: '222222222222', regions: ['eu-west-1', 'us-east-1'] },
+      manualApproval: true,
+      deployment: { deployRole: 'arn:aws:iam::222222222222:role/automation-deployer' },
+    },
   ],
 });
 ```
 
-Each stage's **version lives in its own config file** in the CD repo (a hash or semver) — *not* baked in
+Each stage's **version lives in its own config file** in the CD repo (a hash or semver) — _not_ baked in
 the image:
 
 ```jsonc
@@ -103,50 +104,47 @@ This renders a second CodePipeline with **one Deploy action per target**. Each a
   `dev` can run a newer version than `prod`, and the version is plain config, reviewable in a PR.
 - **Parallel deploys:** ungated targets deploy in parallel; a gated target (e.g. `int`/`prod`) waits on its
   **manual-approval** action, then runs — so `int` and `prod` promote in parallel once approved.
-- **Two pipelines total:** the CI pipeline (Repo 1) *pushes* the image; the CD pipeline (Repo 2) *pulls* it.
+- **Two pipelines total:** the CI pipeline (Repo 1) _pushes_ the image; the CD pipeline (Repo 2) _pulls_ it.
 
 <!-- SCREENSHOT: CodePipeline console showing the Repo 2 CD pipeline as Source → Deploy (per-target actions) -->
 
 <!-- SCREENSHOT: CodePipeline console showing the Repo 2 CD pipeline as Source → Deploy (CodeBuild) -->
 
 !!! tip "Run it locally without a pipeline"
-    The CodeBuild step is just the `cdk-cicd deploy --from-image --yes` executor, which you can also run
-    from any machine or CI runner (it pulls the image and deploys each target). Omit `repository` from
-    `deploy.config.ts` to use only the local executor with no CD pipeline. On a runner whose default docker
-    network can't reach AWS, add `--docker-network host`.
+The CodeBuild step is just the `cdk-cicd deploy --from-image --yes` executor, which you can also run
+from any machine or CI runner (it pulls the image and deploys each target). Omit `repository` from
+`deploy.config.ts` to use only the local executor with no CD pipeline. On a runner whose default docker
+network can't reach AWS, add `--docker-network host`.
 
 Either way, the pinned image runs **once per (target × region)**: for each run the container synthesizes
 that stage against the target's injected environment — offline, inside the image — and deploys the result.
-One build produces one image, and that image drives *N* deploys.
+One build produces one image, and that image drives _N_ deploys.
 
 !!! info "Division of authority: WHAT vs WHERE"
-    The **image** is authoritative for *what* to deploy — the app code and its stage definitions are baked
-    in at build time. The **`deploy.config.ts` target** is authoritative for *where* — the account,
-    region(s), and role for each stage. A target's `deployment.deployRole` (chapter 2's shape) is threaded
-    through to each target's deploy.
+The **image** is authoritative for _what_ to deploy — the app code and its stage definitions are baked
+in at build time. The **`deploy.config.ts` target** is authoritative for _where_ — the account,
+region(s), and role for each stage. A target's `deployment.deployRole` (chapter 2's shape) is threaded
+through to each target's deploy.
 
-!!! warning "Manual-approval gates today"
-    A target's `manualApproval: true` is honored by the **local executor** (`cdk-cicd deploy --from-image`
-    is fail-closed — it refuses a gated target unless you pass `--yes`). The **CD pipeline** currently runs
-    every target in one CodeBuild pass, so it does not yet render per-target Manual Approval actions —
-    per-target pipeline gates are a planned refinement. Until then, gate at the pipeline level (e.g. a
-    separate approval before the CD pipeline) or use the local executor for gated targets.
+!!! info "Manual-approval gates"
+A target's `manualApproval: true` is honored on both paths. The **CD pipeline** renders two deploy
+stages: a `Deploy` stage runs every ungated target in parallel, then a `DeployGated` stage places each
+gated target behind its own manual-approval action (so `int` and `prod` each wait on their own
+approval, then deploy). The **local executor** (`cdk-cicd deploy --from-image`) is fail-closed — it
+refuses a gated target unless you pass `--yes`.
 
 !!! tip "Rollback is a retag"
-    To roll back, point `image:` at the previous version tag (e.g. `:1.4.1`) and re-run
-    `cdk-cicd deploy --from-image`. Because the image pins code + deps and config supplies the lookups,
-    the same image + same config always synthesizes the same template — a deterministic rollback with no
-    rebuild.
+To roll back, point `image:` at the previous version tag (e.g. `:1.4.1`) and re-run
+`cdk-cicd deploy --from-image`. Because the image pins code + deps and config supplies the lookups,
+the same image + same config always synthesizes the same template — a deterministic rollback with no
+rebuild.
 
 ## Verify
 
-!!! success "Verify"
-    - **Repo 1 (CI pipeline):** renders as `Source → BuildImage` (no deploy stages), and after a run the
-      tagged image is present in ECR (`aws ecr describe-images --repository-name my-app-deployer`).
-    - **Repo 2 (CD pipeline):** `deploy-ci` provisions a `Source → Deploy` CodePipeline; a config change
-      triggers the CodeBuild that pulls the image and creates/updates each target's CloudFormation stack.
-    - Change nothing but the `image:` tag and re-run — the deploy reproduces the pinned version, proving
-      one image serves many deployments and rollbacks.
+!!! success "Verify" - **Repo 1 (CI pipeline):** renders as `Source → BuildImage` (no deploy stages), and after a run the
+tagged image is present in ECR (`aws ecr describe-images --repository-name my-app-deployer`). - **Repo 2 (CD pipeline):** `deploy-ci` provisions a `Source → Deploy` CodePipeline; a config change
+triggers the CodeBuild that pulls the image and creates/updates each target's CloudFormation stack. - Change nothing but the `image:` tag and re-run — the deploy reproduces the pinned version, proving
+one image serves many deployments and rollbacks.
 
 ## Recap
 


### PR DESCRIPTION
Closes #238.

Container mode (the two-repository Docker deploy) was documented only in the workshop and `MIGRATION.md` — no reference-doc coverage, and the config reference omits it.

## Change
- New developer guide `docs/content/developer_guides/container_mode.md`, wired into the nav after Continuous Deployment. Covers: CodePipeline-engine-only support, Repo 1 `deployerImage: BuildImage.docker(...)` (`Source -> BuildImage`, ECR provisioning, tag strategy), Repo 2 `defineDeployment` + per-stage `config/<stage>.json` version files, the `cdk-cicd deploy --from-image` local executor, WHAT-vs-WHERE division of authority, and rollback-by-retag. All verified against `src/config/build-image.ts`, `src/engine/codepipeline/DeploymentPipeline.ts`, and `cmds/autopilot/DeployFromImage.ts`.
- Fix a **stale** note in the workshop `05-container-mode.md`: it claimed the CD pipeline "does not yet render per-target Manual Approval actions", but `DeploymentPipeline.ts` renders a `Deploy` stage (ungated, parallel) plus a `DeployGated` stage with one `ManualApprovalAction` per gated target. Corrected the admonition to match.

## Testing
- `npx prettier --check` passes on the changed files.