### PR TITLE
feat: add configurable pipelineStackName for the self-mutating engines

### DIFF
--- a/docs/content/developer_guides/configuration.md
+++ b/docs/content/developer_guides/configuration.md
@@ -21,6 +21,7 @@ export default defineCICD({
 | ------------------------- | ----------------------------- | -------------------------------------- | --------------------------------------------------------------------------- |
 | `application`             | `string`                      | —                                      | Application name; drives the bootstrap qualifier and asset naming.          |
 | `qualifier`               | `string`                      | derived from `application` (≤10 chars) | CDK bootstrap qualifier.                                                    |
+| `pipelineStackName`       | `string`                      | `${application}-pipeline`              | CloudFormation stack name for the self-mutating pipeline stack (`CDK_PIPELINES`/`GITHUB_ACTIONS`). See [Pipeline stack name](#pipeline-stack-name). |
 | `repository`              | `Repository`                  | — (required)                           | The pipeline's source. See [Repository](#repository).                       |
 | `stages`                  | `Array<string \| StageInput>` | — (required)                           | Deployment stages, in order. See [Stages](#stages).                         |
 | `engine`                  | `EngineType`                  | `CODEPIPELINE`                         | Which engine renders the pipeline. See [Engine](#engine).                   |
@@ -47,6 +48,36 @@ export default defineCICD({
 `application` names the app and drives asset naming. `qualifier` is the CDK bootstrap qualifier; when
 omitted it is derived from `application` — lowercased, non-alphanumerics stripped, truncated to 10
 characters (falling back to `cdkcicd` if that leaves nothing).
+
+## Pipeline stack name
+
+The `CDK_PIPELINES` and `GITHUB_ACTIONS` engines assemble their own self-mutating pipeline stack, named
+`${application}-pipeline` by default. `pipelineStackName` overrides the CloudFormation stack name of
+that stack:
+
+```typescript
+export default defineCICD({
+  application: 'automation',
+  pipelineStackName: 'automation', // deploy the pipeline stack as `automation`, not `automation-pipeline`
+  repository: Repository.codecommit('automation'),
+  engine: EngineType.CDK_PIPELINES,
+  stages: [/* … */],
+});
+```
+
+Set it to preserve a pre-1.x (Blueprint) pipeline stack name when migrating an **already-deployed**
+pipeline. A deployed pipeline is self-mutating: its `SelfMutate` step runs `cdk deploy <stackName>`, and
+a self-mutating pipeline cannot rename its own root stack in place — so if the synthesized stack name
+changes from the deployed one, `SelfMutate` fails with `No stacks match the name(s) <oldName>`. Pinning
+the name back to the deployed value lets the existing pipeline update in place, avoiding a disruptive
+rename cutover (pipeline outage plus, where the pipeline pins cross-account role names, a manual
+role-name resequencing).
+
+The override changes **only** the CloudFormation `stackName`. The construct id stays
+`${application}-pipeline`, so the pipeline's child resource logical IDs (roles, CodeBuild projects,
+artifact buckets) — which derive from the construct node path — are unchanged from the default. It does
+not restore pre-1.x child logical IDs; it is scoped to the pipeline stack name only. Omitting the field
+keeps the `${application}-pipeline` default, so existing consumers are unaffected.
 
 ## Repository
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/API.md
+++ b/packages/@cdklabs/cdk-cicd-wrapper/API.md
@@ -3270,6 +3270,7 @@ const resolvedCicdConfig: ResolvedCicdConfig = { ... }
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.ResolvedCicdConfig.property.githubActions">githubActions</a></code> | <code><a href="#@cdklabs/cdk-cicd-wrapper.GitHubActionsConfig">GitHubActionsConfig</a></code> | GitHub Actions engine configuration. |
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.ResolvedCicdConfig.property.npmRegistry">npmRegistry</a></code> | <code><a href="#@cdklabs/cdk-cicd-wrapper.NpmRegistryConfig">NpmRegistryConfig</a></code> | Generic private npm registry the builds authenticate against with a bearer token, if any. |
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.ResolvedCicdConfig.property.pipelineRoleNames">pipelineRoleNames</a></code> | <code><a href="#@cdklabs/cdk-cicd-wrapper.PipelineRoleNames">PipelineRoleNames</a></code> | Forced IAM role names for the CDK Pipelines (`CDK_PIPELINES`) engine's own roles. |
+| <code><a href="#@cdklabs/cdk-cicd-wrapper.ResolvedCicdConfig.property.pipelineStackName">pipelineStackName</a></code> | <code>string</code> | CloudFormation stack name for the engine-owned self-mutating pipeline stack (the one the `CDK_PIPELINES` and `GITHUB_ACTIONS` engines assemble). |
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.ResolvedCicdConfig.property.plugins">plugins</a></code> | <code><a href="#@cdklabs/cdk-cicd-wrapper.PluginRef">PluginRef</a>[]</code> | Security plugins (hardening Aspects) to apply tree-wide, by `{ name, version }` (issue #241). |
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.ResolvedCicdConfig.property.proxy">proxy</a></code> | <code><a href="#@cdklabs/cdk-cicd-wrapper.ProxyConfig">ProxyConfig</a></code> | HTTP(S) proxy every build project routes through, if any. |
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.ResolvedCicdConfig.property.qualifier">qualifier</a></code> | <code>string</code> | Bootstrap qualifier (≤10 chars), derived from `application` when not given. |
@@ -3527,6 +3528,22 @@ Forced IAM role names for the CDK Pipelines (`CDK_PIPELINES`) engine's own roles
 
 Only read when
 `engine` is `EngineType.CDK_PIPELINES`; omitted fields keep CDK-generated names.
+
+---
+
+##### `pipelineStackName`<sup>Optional</sup> <a name="pipelineStackName" id="@cdklabs/cdk-cicd-wrapper.ResolvedCicdConfig.property.pipelineStackName"></a>
+
+```typescript
+public readonly pipelineStackName: string;
+```
+
+- *Type:* string
+- *Default:* `${application}-pipeline`  Set this to preserve a pre-1.x (Blueprint) pipeline stack name so an already-deployed, self-mutating pipeline can update IN PLACE instead of requiring a rename cutover -- the pipeline's `SelfMutate` step runs `cdk deploy <thisName>`, and a self-mutating pipeline cannot rename its own root stack. Changes ONLY the CloudFormation `stackName`, never the construct id, so the pipeline's child logical IDs are unchanged from the default. Same Blueprint-parity family as `pipelineRoleNames`.
+
+CloudFormation stack name for the engine-owned self-mutating pipeline stack (the one the `CDK_PIPELINES` and `GITHUB_ACTIONS` engines assemble).
+
+Only read by those self-mutating engines;
+the flat `CODEPIPELINE` engine names its stack from the user's own `bin`.
 
 ---
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/config/define.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/config/define.ts
@@ -76,6 +76,12 @@ export interface ProxyConfigInput {
 export interface CicdConfigProps {
   readonly application?: string;
   readonly qualifier?: string;
+  /**
+   * CloudFormation stack name for the engine-owned self-mutating pipeline stack. See
+   * `ResolvedCicdConfig.pipelineStackName`. Defaults to `${application}-pipeline`; set it to pin a
+   * pre-1.x (Blueprint) pipeline stack name for an in-place migration.
+   */
+  readonly pipelineStackName?: string;
   readonly repository: Repository;
   /** Each stage is either a bare name (`'dev'`) or a full object. */
   readonly stages: Array<string | StageInput>;
@@ -188,6 +194,7 @@ export function resolveCicdConfig(props: CicdConfigProps): ResolvedCicdConfig {
   return {
     application,
     qualifier: props.qualifier ?? (application !== undefined ? deriveQualifier(application) : undefined),
+    pipelineStackName: props.pipelineStackName,
     repository: props.repository,
     stages,
     synthesizer: { type: props.synthesizer?.type ?? SynthesizerType.DEFAULT },

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/config/types.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/config/types.ts
@@ -331,6 +331,19 @@ export interface ResolvedCicdConfig {
   readonly application?: string;
   /** Bootstrap qualifier (≤10 chars), derived from `application` when not given. */
   readonly qualifier?: string;
+  /**
+   * CloudFormation stack name for the engine-owned self-mutating pipeline stack (the one the
+   * `CDK_PIPELINES` and `GITHUB_ACTIONS` engines assemble). Only read by those self-mutating engines;
+   * the flat `CODEPIPELINE` engine names its stack from the user's own `bin`.
+   * @default `${application}-pipeline`
+   *
+   * Set this to preserve a pre-1.x (Blueprint) pipeline stack name so an already-deployed,
+   * self-mutating pipeline can update IN PLACE instead of requiring a rename cutover -- the pipeline's
+   * `SelfMutate` step runs `cdk deploy <thisName>`, and a self-mutating pipeline cannot rename its own
+   * root stack. Changes ONLY the CloudFormation `stackName`, never the construct id, so the pipeline's
+   * child logical IDs are unchanged from the default. Same Blueprint-parity family as `pipelineRoleNames`.
+   */
+  readonly pipelineStackName?: string;
   /** The source repository. */
   readonly repository: Repository;
   /** The deployment stages, in order. */

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/runtime/pipeline-assembler.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/runtime/pipeline-assembler.ts
@@ -155,7 +155,13 @@ export function replayStageProvider(entry: string): IStageProvider {
  */
 export function buildPipelineApp(config: ResolvedCicdConfig, provider: IStageProvider): App {
   const app = new App();
-  const name = `${config.application ?? DEFAULT_APPLICATION}-pipeline`;
+  // The construct id stays `${application}-pipeline` regardless of any stack-name override: the
+  // pipeline's child logical IDs derive from the construct node path (`<id>/Cd/Pipeline/…`), so
+  // changing the id would churn every child logical ID. `pipelineStackName` overrides ONLY the
+  // CloudFormation stackName, which is what lets an already-deployed self-mutating pipeline update in
+  // place (its `SelfMutate` runs `cdk deploy <stackName>`) without a rename cutover.
+  const constructId = `${config.application ?? DEFAULT_APPLICATION}-pipeline`;
+  const stackName = config.pipelineStackName ?? constructId;
   // Ambient credentials win when present (a real `deploy-ci` run, or any locally-authenticated synth).
   // Falling back to the first stage's env keeps the pipeline stack's account/region reproducible when
   // no credentials are active -- e.g. the GitHub Actions engine's own self-mutation "Synthesize" job,
@@ -163,17 +169,20 @@ export function buildPipelineApp(config: ResolvedCicdConfig, provider: IStagePro
   // to pass cdk-pipelines-github's "commit the updated workflow file" check (a token there is never
   // stable across runs).
   const firstStage = config.stages[0];
-  const stack = new Stack(app, name, {
-    stackName: name,
+  const stack = new Stack(app, constructId, {
+    stackName,
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT ?? firstStage?.env.account,
       region: process.env.CDK_DEFAULT_REGION ?? firstStage?.env.regions[0],
     } as Environment,
   });
+  // `pipelineName` is the construct id, not the (possibly overridden) stackName: the GitHub Actions
+  // engine embeds it as a stable literal the "commit the updated workflow file" self-mutation check
+  // compares across runs, so it must not vary with a CloudFormation stack-name override.
   if (config.engine === EngineType.GITHUB_ACTIONS) {
-    new GitHubActionsEngine(stack, 'Cd', { config, pipelineName: name, stages: provider });
+    new GitHubActionsEngine(stack, 'Cd', { config, pipelineName: constructId, stages: provider });
   } else {
-    new CdkPipelinesEngine(stack, 'Cd', { config, pipelineName: name, stages: provider });
+    new CdkPipelinesEngine(stack, 'Cd', { config, pipelineName: constructId, stages: provider });
   }
   Aspects.of(app).add(new AwsSolutionsChecks({ verbose: false }));
   return app;

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/runtime/pipeline-assembler.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/runtime/pipeline-assembler.test.ts
@@ -73,6 +73,69 @@ describe('CDK Pipelines assembler: pipeline structure (stub provider)', () => {
   });
 });
 
+describe('CDK Pipelines assembler: pipelineStackName override', () => {
+  const prev = { a: process.env.CDK_DEFAULT_ACCOUNT, r: process.env.CDK_DEFAULT_REGION };
+  beforeEach(() => {
+    process.env.CDK_DEFAULT_ACCOUNT = '111111111111';
+    process.env.CDK_DEFAULT_REGION = 'us-east-1';
+  });
+  afterEach(() => {
+    process.env.CDK_DEFAULT_ACCOUNT = prev.a;
+    process.env.CDK_DEFAULT_REGION = prev.r;
+  });
+
+  function pinnedConfig() {
+    return defineCICD({
+      application: 'automation',
+      pipelineStackName: 'automation',
+      repository: Repository.codecommit('automation'),
+      engine: EngineType.CDK_PIPELINES,
+      stages: ['dev'],
+    });
+  }
+
+  test('renders the pipeline stack with the overridden CloudFormation stackName', () => {
+    const app = buildPipelineApp(pinnedConfig(), new StubProvider());
+    // The construct id is unchanged (`${application}-pipeline`), so the stack is still found by it...
+    const stack = app.node.findChild('automation-pipeline') as Stack;
+    // ...but its CloudFormation stack name is the override.
+    expect(stack.stackName).toBe('automation');
+  });
+
+  test('the construct id stays `${application}-pipeline`, so child logical IDs are unchanged', () => {
+    const withOverride = buildPipelineApp(pinnedConfig(), new StubProvider());
+    const withoutOverride = buildPipelineApp(
+      defineCICD({
+        application: 'automation',
+        repository: Repository.codecommit('automation'),
+        engine: EngineType.CDK_PIPELINES,
+        stages: ['dev'],
+      }),
+      new StubProvider(),
+    );
+    // Same construct id both ways.
+    const a = withOverride.node.findChild('automation-pipeline') as Stack;
+    const b = withoutOverride.node.findChild('automation-pipeline') as Stack;
+    // The pipeline role's logical id derives from the construct node path -- identical with and without
+    // the stackName override (only the CFN stackName differs).
+    const roleIds = (s: Stack) => Object.keys(Template.fromStack(s).findResources('AWS::IAM::Role')).sort();
+    expect(roleIds(a)).toEqual(roleIds(b));
+  });
+
+  test('omitting pipelineStackName keeps the `${application}-pipeline` default', () => {
+    const stack = buildPipelineApp(
+      defineCICD({
+        application: 'automation',
+        repository: Repository.codecommit('automation'),
+        engine: EngineType.CDK_PIPELINES,
+        stages: ['dev'],
+      }),
+      new StubProvider(),
+    ).node.findChild('automation-pipeline') as Stack;
+    expect(stack.stackName).toBe('automation-pipeline');
+  });
+});
+
 describe('self-mutating assembler: GITHUB_ACTIONS picks the GitHubActionsEngine', () => {
   const prev = { a: process.env.CDK_DEFAULT_ACCOUNT, r: process.env.CDK_DEFAULT_REGION };
   let workflowDir: string;
@@ -102,6 +165,24 @@ describe('self-mutating assembler: GITHUB_ACTIONS picks the GitHubActionsEngine'
     expect(stack.node.tryFindChild('Cd')).toBeInstanceOf(GitHubActionsEngine);
     // No AWS-hosted CodePipeline: GitHub Actions renders a workflow file, not a CodePipeline resource.
     Template.fromStack(stack).resourceCountIs('AWS::CodePipeline::Pipeline', 0);
+  });
+
+  test('pipelineStackName overrides the CloudFormation stackName but not the construct id', () => {
+    const app = buildPipelineApp(
+      defineCICD({
+        application: 'shop',
+        pipelineStackName: 'shop',
+        repository: Repository.github('org/shop'),
+        stages: ['dev'],
+        engine: EngineType.GITHUB_ACTIONS,
+        githubActions: { workflowPath: path.join(workflowDir, '.github', 'workflows', 'deploy.yml') },
+      }),
+      new StubProvider(),
+    );
+    // Construct id preserved (the stable literal the workflow's self-mutation check compares)...
+    const stack = app.node.findChild('shop-pipeline') as Stack;
+    // ...while the CloudFormation stack name is the override.
+    expect(stack.stackName).toBe('shop');
   });
 });
 


### PR DESCRIPTION
## Summary

Add an optional `pipelineStackName` to `defineCICD` so a consumer can override the CloudFormation stack name of the engine-owned self-mutating pipeline stack. Today the `CDK_PIPELINES` and `GITHUB_ACTIONS` engines hardcode it to `${application}-pipeline`, which makes a Blueprint→Autopilot migration of an **already-deployed** pipeline unable to preserve the pre-1.x stack name.

## Why

A deployed pipeline is self-mutating: its `SelfMutate` step runs `cdk deploy <stackName>`, and a self-mutating pipeline cannot rename its own root stack in place. Once the code is migrated to 1.x, the synthesized name becomes `<application>-pipeline`, so `SelfMutate` fails with `No stacks match the name(s) <oldName>`. The only recovery today is a manual out-of-band cutover (retire the old stack, deploy the new one) — a pipeline outage plus, where the pipeline pins cross-account role names, a hand-sequenced role-name collision.

Pinning the stack name to the deployed value lets the existing pipeline update **in place**. Same Blueprint-parity family as `pipelineRoleNames`.

## Change

- `pipelineStackName?: string` added to `CicdConfigProps` (input) and the jsii-modeled `ResolvedCicdConfig`, threaded through `resolveCicdConfig`.
- `buildPipelineApp` now uses `stackName = config.pipelineStackName ?? constructId`.

### Key design point — construct id vs stackName

The override changes **only** the CloudFormation `stackName`. The construct id stays `${application}-pipeline`, because the pipeline's child resource logical IDs derive from the construct node path (`<id>/Cd/Pipeline/…`) — changing the id would churn every child logical ID (roles, CodeBuild projects, artifact buckets). `pipelineName` passed to both engines now tracks the **construct id**, not the override, so the GitHub Actions "commit the updated workflow file" self-mutation check keeps a stable literal.

Scoped to the pipeline stack name only; it does not restore pre-1.x child logical IDs.

## Acceptance criteria

- [x] `defineCICD({ application: 'automation', pipelineStackName: 'automation', … })` renders the pipeline stack with CloudFormation `stackName: 'automation'`.
- [x] Omitting `pipelineStackName` keeps the current `${application}-pipeline` default (no behaviour change).
- [x] The construct id stays `${application}-pipeline` regardless of the override, so child logical IDs are unchanged (test compares IAM role logical IDs with/without the override).
- [x] Applies to both self-mutating engines (`CDK_PIPELINES` and `GITHUB_ACTIONS`); the GitHub Actions `pipelineName` wiring still uses the construct id.
- [x] Documented in `configuration.md` (config reference + doc-coverage gate) and `API.md` (jsii-docgen, regenerated).

## Testing

- New `pipelineStackName` describe block in `test/runtime/pipeline-assembler.test.ts` (override, default, construct-id-stable, GitHub Actions).
- Assembler + docs-coverage suites: 67 passed, 1 skipped (the compiled-lib subprocess replay test, unrelated).
- `tsc --noEmit` clean, eslint clean.

## Impact if not addressed

Every Blueprint→Autopilot migration of an already-deployed self-mutating pipeline hits a mandatory rename cutover (outage + manual cross-account role resequencing). Concretely unblocks the tef-ivms-automation-core in-place migration.