### PR TITLE
feat(ci)!: default CI to project golden-path npm scripts

### DIFF
--- a/docs/content/developer_guides/ci.md
+++ b/docs/content/developer_guides/ci.md
@@ -17,6 +17,9 @@ cdk synth (+ CDK Nag)
 
 `cdk synth` is always appended at the end and is **never** replaced by `ci.steps` — dropping it would render a pipeline with nothing to deploy. Setting `ci.steps`, however, **replaces** the entire default build phase (including its `npm ci`) rather than adding to it — a project that configures its own steps owns its build phase and is responsible for its own `npm ci`.
 
+!!! important
+    The pipeline runs **`npm run cdk synth`**, not `npx cdk synth`, so it uses the exact `aws-cdk` version pinned in your project — the pipeline never resolves a tool through `npx`, which is non-deterministic. This requires your `package.json` to define a `cdk` script (e.g. `"cdk": "cdk"`), which is the expected shape for a CDK app. A project without a `cdk` script fails at the synth step.
+
 ## Default build phase: your own npm scripts
 
 With no `ci.steps` configured, the CI build runs the project's own npm scripts, in order:

--- a/docs/content/developer_guides/ci.md
+++ b/docs/content/developer_guides/ci.md
@@ -11,16 +11,15 @@ The CI functionality of the {{ project_name }} can be used in any software devel
 There is no `PhaseCommand`/`definePhase` model in Autopilot. The CI build's commands, per `CiConfig` (the `ci` field on `cicd.config.ts`), are:
 
 ```
-npm ci
-<your ci.steps, in the order you wrote them — or, if you set none, the default golden-path scripts (npm run audit / build / test)>
+<your ci.steps verbatim, in the order you wrote them — or, if you set none, the default: npm ci then npm run audit / build / test>
 cdk synth (+ CDK Nag)
 ```
 
-`cdk synth` is always appended at the end and is **never** replaced by `ci.steps` — dropping it would render a pipeline with nothing to deploy. Setting `ci.steps`, however, **replaces** the default golden-path scripts rather than adding to them — a project that configures its own steps owns its build phase.
+`cdk synth` is always appended at the end and is **never** replaced by `ci.steps` — dropping it would render a pipeline with nothing to deploy. Setting `ci.steps`, however, **replaces** the entire default build phase (including its `npm ci`) rather than adding to it — a project that configures its own steps owns its build phase and is responsible for its own `npm ci`.
 
 ## Default build phase: your own npm scripts
 
-With no `ci.steps` configured, the CI build runs the project's own golden-path npm scripts, in order:
+With no `ci.steps` configured, the CI build runs the project's own npm scripts, in order:
 
 ```
 npm ci
@@ -36,7 +35,7 @@ Each script runs only when your `package.json` actually defines it. A missing sc
 
 ## Adding your own build steps
 
-Set `ci.steps` in `cicd.config.ts` — a named map of shell commands, run in the order they appear. This **replaces** the default golden-path scripts, so list everything you want the build to run:
+Set `ci.steps` in `cicd.config.ts` — a named map of shell commands, run in the order they appear. This **replaces** the default scripts entirely, so list everything you want the build to run, **including `npm ci`** (the engine injects nothing of its own when you configure `ci.steps`):
 
 ```typescript
 import { defineCICD, Repository } from '@cdklabs/cdk-cicd-wrapper';
@@ -47,6 +46,7 @@ export default defineCICD({
   stages: ['dev', 'prod'],
   ci: {
     steps: {
+      install: 'npm ci',
       audit: 'npm run audit',
       build: 'npm run build',
       test: 'npm run test',
@@ -55,7 +55,7 @@ export default defineCICD({
 });
 ```
 
-`npm ci` runs before your steps and `cdk synth` after them, regardless of what you configure.
+Only `cdk synth` is appended after your steps; nothing is prepended. (With **no** `ci.steps` configured, the default build begins with its own `npm ci` — see above.)
 
 ### Controlling which stages CI synthesizes
 

--- a/docs/content/developer_guides/ci.md
+++ b/docs/content/developer_guides/ci.md
@@ -12,26 +12,31 @@ There is no `PhaseCommand`/`definePhase` model in Autopilot. The CI build's comm
 
 ```
 npm ci
-<your ci.steps, in the order you wrote them — or, if you set none, the single default step "npx cdk-cicd check">
+<your ci.steps, in the order you wrote them — or, if you set none, the default golden-path scripts (npm run audit / build / test)>
 cdk synth (+ CDK Nag)
 ```
 
-`cdk synth` is always appended at the end and is **never** replaced by `ci.steps` — dropping it would render a pipeline with nothing to deploy. Setting `ci.steps`, however, **replaces** the default `npx cdk-cicd check` step rather than adding to it, so include it explicitly if you still want those checks alongside your own commands.
+`cdk synth` is always appended at the end and is **never** replaced by `ci.steps` — dropping it would render a pipeline with nothing to deploy. Setting `ci.steps`, however, **replaces** the default golden-path scripts rather than adding to them — a project that configures its own steps owns its build phase.
 
-## Default checks: `cdk-cicd check`
+## Default build phase: your own npm scripts
 
-With no `ci.steps` configured, the CI build runs `npx cdk-cicd check`, which itself runs four sub-checks in order — `validate`, `audit`, `license`, `security` — each **skipped**, not failed, when the project has no baseline for it (a fresh `cdk init`-ed project has to pass this):
+With no `ci.steps` configured, the CI build runs the project's own golden-path npm scripts, in order:
 
-| Check | What it runs | Skipped when |
-| --- | --- | --- |
-| `validate` | `cdk-cicd validate` — lock-file checksum against `package-verification.json` | no lock file, or no `package-verification.json` yet (run `cdk-cicd validate --fix`) |
-| `audit` | `cdk-cicd check-dependencies --npm`/`--python` — see the [Audit guide](./audit.md) | no npm lock file and no `Pipfile` |
-| `license` | `cdk-cicd license` — open-source license checking against `package-verification.json` | no `package-verification.json` yet (run `cdk-cicd license --fix`) |
-| `security` | `cdk-cicd security-scan --bandit --shellcheck --semgrep` — see the [Security guide](./security.md) | never (always runs) |
+```
+npm ci
+npm run audit   # if the script exists; else a warning pointing at the recommended checks
+npm run build   # if the script exists; else a warning
+npm run test    # if the script exists; else a warning
+```
+
+Each script runs only when your `package.json` actually defines it. A missing script prints a warning that points at the [recommended checks](./audit.md) and **continues** — it never fails the build. This keeps the checks as encouraged guidance rather than hard enforcement, and keeps CI identical to what you run locally (`npm run audit` behaves the same on a laptop). A project that defines none of these scripts still builds and synthesizes; you just get three warnings in the build log.
+
+!!! tip
+    The wrapper's own checks are still available as scripts you can point these at — e.g. `"audit": "cdk-cicd check-dependencies --npm"` in your `package.json`. See the [Audit guide](./audit.md) and [Security guide](./security.md) for the recommended commands.
 
 ## Adding your own build steps
 
-Set `ci.steps` in `cicd.config.ts` — a named map of shell commands, run in the order they appear:
+Set `ci.steps` in `cicd.config.ts` — a named map of shell commands, run in the order they appear. This **replaces** the default golden-path scripts, so list everything you want the build to run:
 
 ```typescript
 import { defineCICD, Repository } from '@cdklabs/cdk-cicd-wrapper';
@@ -42,7 +47,7 @@ export default defineCICD({
   stages: ['dev', 'prod'],
   ci: {
     steps: {
-      check: 'npx cdk-cicd check', // keep the default checks alongside your own steps
+      audit: 'npm run audit',
       build: 'npm run build',
       test: 'npm run test',
     },

--- a/docs/content/developer_guides/security.md
+++ b/docs/content/developer_guides/security.md
@@ -1,6 +1,6 @@
 # Security on {{ project_name }}
 
-{{ project_name }} brings infrastructure-as-code security to a new level with built-in toolsets based on AWS best practices and industry-wide standards. It includes Static Application Security Testing (SAST) and dependency vulnerability scanning, run through `cdk-cicd check`/`cdk-cicd security-scan`/`cdk-cicd check-dependencies` — no package.json script surgery needed.
+{{ project_name }} brings infrastructure-as-code security to a new level with built-in toolsets based on AWS best practices and industry-wide standards. It includes Static Application Security Testing (SAST) and dependency vulnerability scanning, available through `cdk-cicd security-scan`/`cdk-cicd check-dependencies`. Wire them into your build by pointing a `ci.steps` entry (or a `package.json` script the default build runs) at these commands — see the [CI guide](./ci.md).
 
 ## Reference sheet of Security controls
 
@@ -63,7 +63,7 @@ More information about [Better NPM Audit](https://www.npmjs.com/package/better-n
 
 #### How to enable / disable
 
-Run `cdk-cicd check-dependencies --npm` (or `cdk-cicd check` without arguments, which includes it as the `audit` check whenever an npm lock file is present). To disable it, remove it from your own `ci.steps` in `cicd.config.ts` if you have replaced the default `cdk-cicd check` step — see the [CI guide](./ci.md).
+Run `cdk-cicd check-dependencies --npm`. This is no longer part of the default build phase, so add it as a `ci.steps` entry in `cicd.config.ts` or as the `audit` script in your `package.json` (which the default build runs as `npm run audit`) — see the [CI guide](./ci.md) and [Audit guide](./audit.md). To disable it, leave that step/script out.
 
 ### pip-audit
 
@@ -73,7 +73,7 @@ More information about [pip-audit](https://pypi.org/project/pip-audit/).
 
 #### How to enable / disable
 
-Run `cdk-cicd check-dependencies --python`. `cdk-cicd check`'s `audit` check includes this automatically whenever a `Pipfile` is present in the project; it is skipped (not failed) otherwise.
+Run `cdk-cicd check-dependencies --python`. Add it as a `ci.steps` entry or `package.json` script to run it in your build; it is not part of the default build phase.
 
 ### Semgrep
 
@@ -82,13 +82,13 @@ runs here is plain `semgrep scan --config p/default` — no login, no `SEMGREP_A
 Supply Chain and Secrets products (dependency-vulnerability scanning, hardcoded-credential detection) are
 **not** what's wired up here; those require the logged-in `semgrep ci` workflow, which this integration
 does not use. Dependency vulnerabilities are covered separately by [Better NPM Audit](#better-npm-audit)
-above; there is no dedicated secrets scanner in the default `cdk-cicd check` pipeline.
+above; there is no dedicated secrets scanner among the wrapper's CI tools.
 
 More information about [Semgrep](https://github.com/returntocorp/semgrep).
 
 #### How to enable / disable
 
-Semgrep runs as part of `cdk-cicd security-scan --semgrep` (or `cdk-cicd check`'s `security` check, which always runs it). There is no per-scanner disable flag exposed through `cdk-cicd check` — replace the default `check` step with your own `ci.steps` (see the [CI guide](./ci.md)) if you need to opt out of an individual scanner.
+Semgrep runs as part of `cdk-cicd security-scan --semgrep` (or `cdk-cicd check`'s `security` check, which always runs it). There is no per-scanner disable flag exposed through `cdk-cicd check` — run `cdk-cicd security-scan` with only the scanners you want as a `ci.steps` entry (see the [CI guide](./ci.md)) if you need to opt out of an individual scanner.
 
 ### Shellcheck
 

--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -105,20 +105,20 @@ npx cdk-cicd deploy-ci
 
 This provisions the pipeline from `cicd.config.ts` alone — nothing else needs to exist yet. From here, the pipeline self-updates from `cicd.config.ts` on every run, so you only run `deploy-ci` by hand once (and again if you ever need to recover a deleted pipeline stack).
 
-Once deployed, the pipeline runs: **Source** → **Build** (`npm ci`, then either your configured `ci.steps` or, if you set none, the default `npx cdk-cicd check`, then `cdk synth` with CDK Nag) → **self-update** → one **deploy** action per configured stage, in order, gated by a manual approval on every stage except your inner-loop ones (`dev`/`res`) unless you set `manualApproval` explicitly.
+Once deployed, the pipeline runs: **Source** → **Build** (`npm ci`, then either your configured `ci.steps` or, if you set none, the default golden-path scripts `npm run audit`/`build`/`test`, then `cdk synth` with CDK Nag) → **self-update** → one **deploy** action per configured stage, in order, gated by a manual approval on every stage except your inner-loop ones (`dev`/`res`) unless you set `manualApproval` explicitly.
 
 ## Configuring Continuous Integration
 
-Leave `ci.steps` unset and the build runs `npx cdk-cicd check` by default — `validate` (lock-file integrity), `audit` (dependency CVE scanning), `license` (open-source license checking), and `security` (Bandit/Semgrep/ShellCheck), each skipped rather than failed when the project has no baseline for it yet (for example a fresh `cdk init`-ed project with no `package-verification.json`).
+Leave `ci.steps` unset and the build runs your project's own golden-path scripts by default — `npm run audit`, `npm run build`, then `npm run test`. Each runs only when your `package.json` defines it; a missing script prints a warning pointing at the recommended checks and continues, so it never fails the build. This keeps CI identical to what you run locally and treats the checks as encouraged guidance. See the [Audit guide](../developer_guides/audit.md) for the recommended `audit` command to point your script at.
 
-Setting `ci.steps` **replaces** that default `cdk-cicd check` step rather than adding to it, so include it explicitly if you still want those checks:
+Setting `ci.steps` **replaces** those default scripts rather than adding to them, so list everything you want the build to run:
 
 ```typescript
 export default defineCICD({
   // ...
   ci: {
     steps: {
-      check: 'npx cdk-cicd check',
+      audit: 'npm run audit',
       build: 'npm run build',
       test: 'npm run test',
     },

--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -105,11 +105,11 @@ npx cdk-cicd deploy-ci
 
 This provisions the pipeline from `cicd.config.ts` alone — nothing else needs to exist yet. From here, the pipeline self-updates from `cicd.config.ts` on every run, so you only run `deploy-ci` by hand once (and again if you ever need to recover a deleted pipeline stack).
 
-Once deployed, the pipeline runs: **Source** → **Build** (`npm ci`, then either your configured `ci.steps` or, if you set none, the default golden-path scripts `npm run audit`/`build`/`test`, then `cdk synth` with CDK Nag) → **self-update** → one **deploy** action per configured stage, in order, gated by a manual approval on every stage except your inner-loop ones (`dev`/`res`) unless you set `manualApproval` explicitly.
+Once deployed, the pipeline runs: **Source** → **Build** (`npm ci`, then either your configured `ci.steps` or, if you set none, the default scripts `npm run audit`/`build`/`test`, then `cdk synth` with CDK Nag) → **self-update** → one **deploy** action per configured stage, in order, gated by a manual approval on every stage except your inner-loop ones (`dev`/`res`) unless you set `manualApproval` explicitly.
 
 ## Configuring Continuous Integration
 
-Leave `ci.steps` unset and the build runs your project's own golden-path scripts by default — `npm run audit`, `npm run build`, then `npm run test`. Each runs only when your `package.json` defines it; a missing script prints a warning pointing at the recommended checks and continues, so it never fails the build. This keeps CI identical to what you run locally and treats the checks as encouraged guidance. See the [Audit guide](../developer_guides/audit.md) for the recommended `audit` command to point your script at.
+Leave `ci.steps` unset and the build runs your project's own npm scripts by default — `npm run audit`, `npm run build`, then `npm run test`. Each runs only when your `package.json` defines it; a missing script prints a warning pointing at the recommended checks and continues, so it never fails the build. This keeps CI identical to what you run locally and treats the checks as encouraged guidance. See the [Audit guide](../developer_guides/audit.md) for the recommended `audit` command to point your script at.
 
 Setting `ci.steps` **replaces** those default scripts rather than adding to them, so list everything you want the build to run:
 

--- a/docs/content/overview/index.md
+++ b/docs/content/overview/index.md
@@ -17,7 +17,7 @@ The {{ project_name }} can address these issues and drastically reduce the effor
 Here are some key features provided by the {{ project_name }}:
 
 - :white_check_mark: **Zero wrapper code in your app** (TypeScript/JavaScript apps) — your `bin/` stays exactly what `cdk init` produced; the pipeline lives in a separate `cicd.config.ts`. Non-Node apps (e.g. Python) use the explicit `CdkCicd.attach(app)` opt-in instead — see [Getting Started](../getting_started/index.md)
-- :white_check_mark: [Customizable CI](../developer_guides/ci.md) steps that default to your project's own golden-path npm scripts (`npm run audit`/`build`/`test`)
+- :white_check_mark: [Customizable CI](../developer_guides/ci.md) steps that default to your project's own npm scripts (`npm run audit`/`build`/`test`)
 - :white_check_mark: Integration of various [security scanning tools](../developer_guides/security.md) (cdk-nag, Bandit, Semgrep, ShellCheck, dependency-vulnerability scanning)
 - :white_check_mark: Multi-staged Continuous Deployment process with manual-approval gating on by default for anything past your inner development loop
 - :white_check_mark: Flexible definition of stages, including multi-region stages and per-stage AWS accounts
@@ -45,7 +45,7 @@ The CI/CD process in the {{ project_name }} establishes the following:
 1. Changes are committed to the Git repository in a branch, and a Pull Request (PR) is created for the tracked branch (`main` by default).
 2. The PR is reviewed, approved, and merged.
 3. Once the codebase is merged, the pipeline is triggered to execute the CI/CD process:
-   - **Build**: This is the Continuous Integration step, which runs your configured `ci.steps` or, by default, your project's golden-path scripts (`npm run audit`/`build`/`test`, each run-if-present) to ensure code quality and security before deployment to any stage.
+   - **Build**: This is the Continuous Integration step, which runs your configured `ci.steps` or, by default, your project's own npm scripts (`npm run audit`/`build`/`test`, each run-if-present) to ensure code quality and security before deployment to any stage.
    - **Synthesize**: This step executes `cdk synth` and runs CDK Nag to promote infrastructure best practices.
    - **Self-update**: The pipeline updates its own definition from the latest `cicd.config.ts`.
    - **Deploy `<stage>`** (one action per configured stage): Updates the infrastructure elements in that stage's account/region with AWS CloudFormation. Stages other than your inner-loop stages (e.g. `dev`/`res`) are gated by a manual approval by default.

--- a/docs/content/overview/index.md
+++ b/docs/content/overview/index.md
@@ -17,7 +17,7 @@ The {{ project_name }} can address these issues and drastically reduce the effor
 Here are some key features provided by the {{ project_name }}:
 
 - :white_check_mark: **Zero wrapper code in your app** (TypeScript/JavaScript apps) — your `bin/` stays exactly what `cdk init` produced; the pipeline lives in a separate `cicd.config.ts`. Non-Node apps (e.g. Python) use the explicit `CdkCicd.attach(app)` opt-in instead — see [Getting Started](../getting_started/index.md)
-- :white_check_mark: [Customizable CI](../developer_guides/ci.md) steps to meet project requirements, run behind one `cdk-cicd check` command
+- :white_check_mark: [Customizable CI](../developer_guides/ci.md) steps that default to your project's own golden-path npm scripts (`npm run audit`/`build`/`test`)
 - :white_check_mark: Integration of various [security scanning tools](../developer_guides/security.md) (cdk-nag, Bandit, Semgrep, ShellCheck, dependency-vulnerability scanning)
 - :white_check_mark: Multi-staged Continuous Deployment process with manual-approval gating on by default for anything past your inner development loop
 - :white_check_mark: Flexible definition of stages, including multi-region stages and per-stage AWS accounts
@@ -45,7 +45,7 @@ The CI/CD process in the {{ project_name }} establishes the following:
 1. Changes are committed to the Git repository in a branch, and a Pull Request (PR) is created for the tracked branch (`main` by default).
 2. The PR is reviewed, approved, and merged.
 3. Once the codebase is merged, the pipeline is triggered to execute the CI/CD process:
-   - **Build**: This is the Continuous Integration step, which runs your configured `ci.steps` plus the default-on `cdk-cicd check` (validate, audit, license, security) to ensure code quality and security before deployment to any stage.
+   - **Build**: This is the Continuous Integration step, which runs your configured `ci.steps` or, by default, your project's golden-path scripts (`npm run audit`/`build`/`test`, each run-if-present) to ensure code quality and security before deployment to any stage.
    - **Synthesize**: This step executes `cdk synth` and runs CDK Nag to promote infrastructure best practices.
    - **Self-update**: The pipeline updates its own definition from the latest `cicd.config.ts`.
    - **Deploy `<stage>`** (one action per configured stage): Updates the infrastructure elements in that stage's account/region with AWS CloudFormation. Stages other than your inner-loop stages (e.g. `dev`/`res`) are gated by a manual approval by default.

--- a/docs/content/workshops/autopilot-pipeline/01-config-driven-pipeline.md
+++ b/docs/content/workshops/autopilot-pipeline/01-config-driven-pipeline.md
@@ -95,9 +95,9 @@ only ever write the few you need, because the wrapper resolves sensible defaults
 
 ## Customizing CI
 
-The `ci` block shapes the Build phase. All three sub-fields are optional; the wrapper's default-on checks
-(`cdk-cicd check` runs validate, audit, license, security) plus the synth step run whether or not you set
-anything.
+The `ci` block shapes the Build phase. All three sub-fields are optional; with none set, the build runs
+your project's own golden-path scripts (`npm run audit`/`build`/`test`, each run-if-present, warn-if-absent)
+plus the synth step.
 
 **Named build steps (`ci.steps`)** — a map of `{ name: shell-command }`. Each entry becomes a named step
 in the CI build, so you add project-specific gates without editing pipeline code:

--- a/docs/content/workshops/autopilot-pipeline/01-config-driven-pipeline.md
+++ b/docs/content/workshops/autopilot-pipeline/01-config-driven-pipeline.md
@@ -96,7 +96,7 @@ only ever write the few you need, because the wrapper resolves sensible defaults
 ## Customizing CI
 
 The `ci` block shapes the Build phase. All three sub-fields are optional; with none set, the build runs
-your project's own golden-path scripts (`npm run audit`/`build`/`test`, each run-if-present, warn-if-absent)
+your project's own npm scripts (`npm run audit`/`build`/`test`, each run-if-present, warn-if-absent)
 plus the synth step.
 
 **Named build steps (`ci.steps`)** — a map of `{ name: shell-command }`. Each entry becomes a named step

--- a/docs/content/workshops/autopilot-pipeline/05-container-mode.md
+++ b/docs/content/workshops/autopilot-pipeline/05-container-mode.md
@@ -35,7 +35,7 @@ export default defineCICD({
 
 `cdk-cicd deploy-ci` provisions a **secondary CodePipeline** whose single build project:
 
-1. runs `npm ci` and your golden-path CI scripts (`npm run audit`/`build`/`test`, CI as a validation gate),
+1. runs `npm ci` and your CI scripts (`npm run audit`/`build`/`test`, CI as a validation gate),
 2. logs in to ECR (`aws ecr get-login-password | docker login …`),
 3. `docker build`s your Dockerfile and pushes the image, tagged by the resolved commit.
 

--- a/docs/content/workshops/autopilot-pipeline/05-container-mode.md
+++ b/docs/content/workshops/autopilot-pipeline/05-container-mode.md
@@ -35,7 +35,7 @@ export default defineCICD({
 
 `cdk-cicd deploy-ci` provisions a **secondary CodePipeline** whose single build project:
 
-1. runs `npm ci` and `cdk-cicd check` (CI as a validation gate),
+1. runs `npm ci` and your golden-path CI scripts (`npm run audit`/`build`/`test`, CI as a validation gate),
 2. logs in to ECR (`aws ecr get-login-password | docker login …`),
 3. `docker build`s your Dockerfile and pushes the image, tagged by the resolved commit.
 

--- a/docs/content/workshops/autopilot-pipeline/index.md
+++ b/docs/content/workshops/autopilot-pipeline/index.md
@@ -21,7 +21,7 @@ and *your* pipeline, not the wrapper's internals:
 | Keep your app portable | Wrap `bin/` in `PipelineBlueprint.builder()…synth(app)` — wrapper code you own forever | An ordinary `cdk init` app. Zero wrapper imports in `bin/` for the basic flow |
 | Describe stages & accounts | Encode them in builder calls + `ACCOUNT_*` env vars | Declare them as data in `cicd.config.ts` — read, diff, and review a plain object |
 | Understand the pipeline | Trace 100+ CodeBuild projects (per-asset, per-stage pre/post, self-mutation) | One flat CodePipeline: `Source → Build → UpdatePipeline → deploy per stage` |
-| Run the CI checks | Wire npm scripts, `jq` surgery, `package-verification.json` | Default-on checks the `cdk-cicd` CLI runs for you — a fresh project passes |
+| Run the CI checks | Wire npm scripts, `jq` surgery, `package-verification.json` | Your own golden-path `npm run` scripts run by default — a fresh project passes, with the wrapper's checks available to point them at |
 | Change the pipeline | Re-run a build command by hand | Edit config, push — the pipeline self-updates before the stages it affects |
 | Scale to many targets | Grow pipeline resources per target | **Container mode**: one config-agnostic image, many deploy targets as config rows |
 | Adopt it on a live app | Risk recreating deployed stacks | A codemod + a stack-name helper that keep already-deployed resources **in place** |

--- a/docs/content/workshops/autopilot-pipeline/index.md
+++ b/docs/content/workshops/autopilot-pipeline/index.md
@@ -21,7 +21,7 @@ and *your* pipeline, not the wrapper's internals:
 | Keep your app portable | Wrap `bin/` in `PipelineBlueprint.builder()…synth(app)` — wrapper code you own forever | An ordinary `cdk init` app. Zero wrapper imports in `bin/` for the basic flow |
 | Describe stages & accounts | Encode them in builder calls + `ACCOUNT_*` env vars | Declare them as data in `cicd.config.ts` — read, diff, and review a plain object |
 | Understand the pipeline | Trace 100+ CodeBuild projects (per-asset, per-stage pre/post, self-mutation) | One flat CodePipeline: `Source → Build → UpdatePipeline → deploy per stage` |
-| Run the CI checks | Wire npm scripts, `jq` surgery, `package-verification.json` | Your own golden-path `npm run` scripts run by default — a fresh project passes, with the wrapper's checks available to point them at |
+| Run the CI checks | Wire npm scripts, `jq` surgery, `package-verification.json` | Your own `npm run` scripts run by default — a fresh project passes, with the wrapper's checks available to point them at |
 | Change the pipeline | Re-run a build command by hand | Edit config, push — the pipeline self-updates before the stages it affects |
 | Scale to many targets | Grow pipeline resources per target | **Container mode**: one config-agnostic image, many deploy targets as config rows |
 | Adopt it on a live app | Risk recreating deployed stacks | A codemod + a stack-name helper that keep already-deployed resources **in place** |

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/cdkpipelines/CdkPipelinesEngine.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/cdkpipelines/CdkPipelinesEngine.ts
@@ -26,6 +26,7 @@ import { CodeArtifactConfig, PipelineRoleNames, ProxyConfig, ResolvedCicdConfig 
 import { AccessLogsForBucketAspect } from '../../support/AccessLogsForBucketAspect';
 import { SupportResources } from '../../support/SupportResources';
 import { resolveVpcNetworking } from '../../support/Vpc';
+import { defaultCiCommands } from '../ci-commands';
 
 /** Context passed to the stage factory for one deployment stage. */
 export interface CdkPipelinesStageContext {
@@ -143,8 +144,9 @@ export class CdkPipelinesEngine extends Construct {
       synth: new pipelines.CodeBuildStep('Synth', {
         input: sourceFor(this, config.repository),
         installCommands,
-        // Run the default CI check, any configured extra steps, then synth the app.
-        commands: ['npm ci', 'npx cdk-cicd check', ...ciSteps, 'npx cdk synth'],
+        // When no ci.steps are configured, run the project's golden-path npm scripts (audit/build/test,
+        // each run-or-warn); otherwise the configured steps replace them. Then synth the app.
+        commands: [...(ciSteps.length > 0 ? ['npm ci', ...ciSteps] : defaultCiCommands()), 'npx cdk synth'],
         env: {
           ...(config.qualifier ? { CDK_QUALIFIER: config.qualifier } : {}),
           AWS_REGION: region,

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/cdkpipelines/CdkPipelinesEngine.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/cdkpipelines/CdkPipelinesEngine.ts
@@ -144,9 +144,10 @@ export class CdkPipelinesEngine extends Construct {
       synth: new pipelines.CodeBuildStep('Synth', {
         input: sourceFor(this, config.repository),
         installCommands,
-        // When no ci.steps are configured, run the project's golden-path npm scripts (audit/build/test,
-        // each run-or-warn); otherwise the configured steps replace them. Then synth the app.
-        commands: [...(ciSteps.length > 0 ? ['npm ci', ...ciSteps] : defaultCiCommands()), 'npx cdk synth'],
+        // With no ci.steps, run the default CI (its own `npm ci` first); with ci.steps, those steps ARE
+        // the build phase verbatim -- the engine injects nothing, not even `npm ci`. Then synth via
+        // `npm run cdk` so the project's pinned aws-cdk is used, not whatever `npx` resolves.
+        commands: [...(ciSteps.length > 0 ? ciSteps : defaultCiCommands()), 'npm run cdk synth'],
         env: {
           ...(config.qualifier ? { CDK_QUALIFIER: config.qualifier } : {}),
           AWS_REGION: region,

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/ci-commands.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/ci-commands.ts
@@ -27,10 +27,11 @@ const CHECKS_DOCS_URL = 'https://cdklabs.github.io/cdk-cicd-wrapper/developer_gu
  * line so it drops straight into a CodeBuild `commands` array or a CDK Pipelines step.
  */
 function runScriptOrWarn(script: string): string {
+  // Double-quote the script name INSIDE the message: the message itself is wrapped in single quotes
+  // for the echo, so an embedded single quote would close that quote in /bin/sh rather than print.
   const warning =
-    `WARNING: no '${script}' script in package.json -- skipping. ` +
-    `The cdk-cicd-wrapper recommends a '${script}' script for your CI checks; see ${CHECKS_DOCS_URL}`;
-  // Single-quote the warning for the echo; the message contains no single quotes.
+    `WARNING: no "${script}" script in package.json -- skipping. ` +
+    `The cdk-cicd-wrapper recommends a "${script}" script for your CI checks; see ${CHECKS_DOCS_URL}`;
   return `if [ "$(npm pkg get scripts.${script})" != "{}" ]; then npm run ${script}; else echo '${warning}'; fi`;
 }
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/ci-commands.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/ci-commands.ts
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The default CI build commands, shared by every engine so all three render the SAME default build
+// phase. When a project configures no `ci.steps`, CI runs the project's own golden-path npm scripts
+// -- `npm run audit`, `npm run build`, `npm run test` -- rather than a bespoke umbrella CLI. Each is
+// run only when the project actually defines that script; a missing script prints a warning that
+// points at our recommended checks and CONTINUES (it never fails the build). This keeps the checks as
+// encouraged guidance -- discoverable and local==CI, since `npm run audit` behaves identically on a
+// laptop -- without enforcing them on a project that has opted out.
+//
+// The moment a project sets its own `ci.steps`, this default is replaced wholesale (the engines own
+// that replacement): a project that customizes CI owns its build phase, warnings included.
+
+/** The golden-path scripts CI runs by default, in order. */
+const DEFAULT_SCRIPTS = ['audit', 'build', 'test'] as const;
+
+/** Where the recommended-checks guidance lives, cited by the missing-script warning. */
+const CHECKS_DOCS_URL = 'https://cdklabs.github.io/cdk-cicd-wrapper/developer_guides/audit/';
+
+/**
+ * A single shell command that runs `npm run <script>` when the project defines it, and otherwise
+ * prints a warning pointing at our recommended checks -- without failing the build.
+ *
+ * `npm pkg get scripts.<name>` prints the script's value, or `{}` when it is absent, so the presence
+ * check needs no `jq` and no parsing of `package.json` by hand. The whole thing is one `sh -c`-safe
+ * line so it drops straight into a CodeBuild `commands` array or a CDK Pipelines step.
+ */
+function runScriptOrWarn(script: string): string {
+  const warning =
+    `WARNING: no '${script}' script in package.json -- skipping. ` +
+    `The cdk-cicd-wrapper recommends a '${script}' script for your CI checks; see ${CHECKS_DOCS_URL}`;
+  // Single-quote the warning for the echo; the message contains no single quotes.
+  return `if [ "$(npm pkg get scripts.${script})" != "{}" ]; then npm run ${script}; else echo '${warning}'; fi`;
+}
+
+/**
+ * The default CI build commands when `ci.steps` is empty: `npm ci`, then each golden-path script
+ * (run-or-warn), in order. `cdk synth` is appended by the engine, not here.
+ */
+export function defaultCiCommands(): string[] {
+  return ['npm ci', ...DEFAULT_SCRIPTS.map(runScriptOrWarn)];
+}

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/ci-commands.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/ci-commands.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // The default CI build commands, shared by every engine so all three render the SAME default build
-// phase. When a project configures no `ci.steps`, CI runs the project's own golden-path npm scripts
+// phase. When a project configures no `ci.steps`, CI runs the project's own npm scripts
 // -- `npm run audit`, `npm run build`, `npm run test` -- rather than a bespoke umbrella CLI. Each is
 // run only when the project actually defines that script; a missing script prints a warning that
 // points at our recommended checks and CONTINUES (it never fails the build). This keeps the checks as
@@ -12,7 +12,7 @@
 // The moment a project sets its own `ci.steps`, this default is replaced wholesale (the engines own
 // that replacement): a project that customizes CI owns its build phase, warnings included.
 
-/** The golden-path scripts CI runs by default, in order. */
+/** The npm scripts CI runs by default, in order. */
 const DEFAULT_SCRIPTS = ['audit', 'build', 'test'] as const;
 
 /** Where the recommended-checks guidance lives, cited by the missing-script warning. */
@@ -36,7 +36,7 @@ function runScriptOrWarn(script: string): string {
 }
 
 /**
- * The default CI build commands when `ci.steps` is empty: `npm ci`, then each golden-path script
+ * The default CI build commands when `ci.steps` is empty: `npm ci`, then each default script
  * (run-or-warn), in order. `cdk synth` is appended by the engine, not here.
  */
 export function defaultCiCommands(): string[] {

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/codepipeline/CodePipelineEngine.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/codepipeline/CodePipelineEngine.ts
@@ -610,11 +610,13 @@ export class CodePipelineEngine implements IEngine {
 
   private ciCommands(config: ResolvedCicdConfig, synthed: string[], promote: boolean): string[] {
     const steps = Object.values(config.ci.steps);
-    const base = steps.length > 0 ? ['npm ci', ...steps] : defaultCiCommands();
+    // With no ci.steps the engine runs the default CI (which begins with its own `npm ci`). With
+    // ci.steps configured, those steps ARE the build phase verbatim -- the engine injects nothing, not
+    // even `npm ci`: a project that customizes CI decides for itself whether and where to install.
+    const base = steps.length > 0 ? steps : defaultCiCommands();
     // The synth is appended, never replaced by `ci.steps`. In promotion mode it produces the artifact
     // every deploy stage consumes, so a config that dropped it would render a pipeline that cannot
-    // deploy at all; in deploy-time-synth mode it is the validation gate. `ci.steps` still replaces the
-    // default golden-path commands wholesale -- a project that customizes CI owns its build phase.
+    // deploy at all; in deploy-time-synth mode it is the validation gate.
     return [...base, ...synthCommands(synthed, promote)];
   }
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/codepipeline/CodePipelineEngine.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/codepipeline/CodePipelineEngine.ts
@@ -39,14 +39,8 @@ import {
 import { AccessLogsForBucketAspect } from '../../support/AccessLogsForBucketAspect';
 import { SupportResources } from '../../support/SupportResources';
 import { VpcNetworking } from '../../support/Vpc';
+import { defaultCiCommands } from '../ci-commands';
 import { EngineRenderProps, IEngine } from '../types';
-
-/**
- * Default CI commands when the config sets none. The engine, not the config layer, owns these.
- * `check` runs the validate/audit/license/security set before synth, which is what makes those checks
- * default-on in CI: a project that configures no `ci.steps` still gets them.
- */
-const DEFAULT_CI_COMMANDS = ['npm ci', 'npx cdk-cicd check'];
 
 /**
  * The CDK bootstrap roles `cdk deploy` assumes: the deploy role drives CloudFormation, the two
@@ -461,8 +455,7 @@ export class CodePipelineEngine implements IEngine {
     const uri = `${stack.account}.dkr.ecr.${stack.region}.${stack.urlSuffix}/${repository.repositoryName}`;
     const commands = [
       ...(config.codeArtifact ? [codeArtifactLogin(stack, config.codeArtifact)] : []),
-      'npm ci',
-      'npx cdk-cicd check',
+      ...defaultCiCommands(),
       // Log in to ECR, build the deployer image from the source, tag by commit, push. The image payload
       // is the app + deps (per the Dockerfile), NOT cdk.out -- Repo 2 synths at run time.
       `aws ecr get-login-password --region ${stack.region} | docker login --username AWS --password-stdin ${stack.account}.dkr.ecr.${stack.region}.${stack.urlSuffix}`,
@@ -617,11 +610,11 @@ export class CodePipelineEngine implements IEngine {
 
   private ciCommands(config: ResolvedCicdConfig, synthed: string[], promote: boolean): string[] {
     const steps = Object.values(config.ci.steps);
-    const base = steps.length > 0 ? ['npm ci', ...steps] : DEFAULT_CI_COMMANDS;
+    const base = steps.length > 0 ? ['npm ci', ...steps] : defaultCiCommands();
     // The synth is appended, never replaced by `ci.steps`. In promotion mode it produces the artifact
     // every deploy stage consumes, so a config that dropped it would render a pipeline that cannot
     // deploy at all; in deploy-time-synth mode it is the validation gate. `ci.steps` still replaces the
-    // check step -- see finding `code-review-ci-steps-replace-drops-checks`, unchanged here.
+    // default golden-path commands wholesale -- a project that customizes CI owns its build phase.
     return [...base, ...synthCommands(synthed, promote)];
   }
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/github/GitHubActionsEngine.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/github/GitHubActionsEngine.ts
@@ -135,7 +135,10 @@ export class GitHubActionsEngine extends Construct {
       workflowTriggers: options.workflowTriggers,
       synth: new CodeBuildStep('Synth', {
         installCommands: [],
-        commands: [...(ciSteps.length > 0 ? ['npm ci', ...ciSteps] : defaultCiCommands()), 'npx cdk synth'],
+        // With no ci.steps, run the default CI (its own `npm ci` first); with ci.steps, those steps ARE
+        // the build phase verbatim -- the engine injects nothing, not even `npm ci`. Then synth via
+        // `npm run cdk` so the project's pinned aws-cdk is used, not whatever `npx` resolves.
+        commands: [...(ciSteps.length > 0 ? ciSteps : defaultCiCommands()), 'npm run cdk synth'],
         env: config.qualifier ? { CDK_QUALIFIER: config.qualifier } : undefined,
         primaryOutputDirectory: 'cdk.out',
       }),

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/github/GitHubActionsEngine.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/github/GitHubActionsEngine.ts
@@ -28,6 +28,7 @@ import { Construct } from 'constructs';
 import { RepositorySourceType } from '../../config/repository';
 import { ProxyConfig, ResolvedCicdConfig } from '../../config/types';
 import { CdkPipelinesStageContext, IStageProvider } from '../cdkpipelines/CdkPipelinesEngine';
+import { defaultCiCommands } from '../ci-commands';
 
 /** Props for the GitHub Actions engine. */
 export interface GitHubActionsEngineProps {
@@ -134,7 +135,7 @@ export class GitHubActionsEngine extends Construct {
       workflowTriggers: options.workflowTriggers,
       synth: new CodeBuildStep('Synth', {
         installCommands: [],
-        commands: ['npm ci', 'npx cdk-cicd check', ...ciSteps, 'npx cdk synth'],
+        commands: [...(ciSteps.length > 0 ? ['npm ci', ...ciSteps] : defaultCiCommands()), 'npx cdk synth'],
         env: config.qualifier ? { CDK_QUALIFIER: config.qualifier } : undefined,
         primaryOutputDirectory: 'cdk.out',
       }),

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/cdkpipelines/cdk-pipelines-engine.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/cdkpipelines/cdk-pipelines-engine.test.ts
@@ -67,7 +67,7 @@ describe('Blueprint-compat: CdkPipelinesEngine (aws-cdk-lib/pipelines)', () => {
     expect(actionCategories('dev')).not.toContain('Approval');
   });
 
-  test('the synth step runs npm ci + the golden-path scripts + cdk synth (CI in the pipeline)', () => {
+  test('the synth step runs npm ci + the default scripts + cdk synth (CI in the pipeline)', () => {
     const t = render();
     // The Synth CodeBuild project's buildspec carries the commands.
     const projects = t.findResources('AWS::CodeBuild::Project');

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/cdkpipelines/cdk-pipelines-engine.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/cdkpipelines/cdk-pipelines-engine.test.ts
@@ -67,12 +67,12 @@ describe('Blueprint-compat: CdkPipelinesEngine (aws-cdk-lib/pipelines)', () => {
     expect(actionCategories('dev')).not.toContain('Approval');
   });
 
-  test('the synth step runs npm ci + cdk-cicd check + cdk synth (CI in the pipeline)', () => {
+  test('the synth step runs npm ci + the golden-path scripts + cdk synth (CI in the pipeline)', () => {
     const t = render();
     // The Synth CodeBuild project's buildspec carries the commands.
     const projects = t.findResources('AWS::CodeBuild::Project');
     const specs = Object.values(projects).map((p: any) => JSON.stringify(p.Properties.Source.BuildSpec));
-    expect(specs.some((s) => s.includes('npm ci') && s.includes('cdk-cicd check') && s.includes('cdk synth'))).toBe(
+    expect(specs.some((s) => s.includes('npm ci') && s.includes('npm run audit') && s.includes('cdk synth'))).toBe(
       true,
     );
   });

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for the shared default CI build commands: the golden-path scripts (audit/build/test)
+// each run-or-warn, in order, with npm ci first. The engines are responsible for appending cdk synth
+// and for replacing this default when ci.steps is set -- those are covered in the engine tests.
+
+import { defaultCiCommands } from '../../src/engine/ci-commands';
+
+describe('defaultCiCommands', () => {
+  const commands = defaultCiCommands();
+
+  test('starts with npm ci', () => {
+    expect(commands[0]).toBe('npm ci');
+  });
+
+  test('runs audit, build, then test after npm ci, in that order', () => {
+    expect(commands).toHaveLength(4);
+    expect(commands[1]).toContain('npm run audit');
+    expect(commands[2]).toContain('npm run build');
+    expect(commands[3]).toContain('npm run test');
+  });
+
+  test('each script is run only when present, else warns and continues (no failure)', () => {
+    for (const [script, cmd] of [
+      ['audit', commands[1]],
+      ['build', commands[2]],
+      ['test', commands[3]],
+    ] as const) {
+      // Presence probe via `npm pkg get` (no jq), run-if-present, warn-if-absent, no non-zero exit.
+      expect(cmd).toContain(`npm pkg get scripts.${script}`);
+      expect(cmd).toContain(`npm run ${script}`);
+      expect(cmd).toMatch(/else echo /);
+      expect(cmd).not.toContain('exit 1');
+    }
+  });
+
+  test('the missing-script warning points at the checks documentation', () => {
+    expect(commands[1]).toContain('https://cdklabs.github.io/cdk-cicd-wrapper/developer_guides/audit/');
+  });
+
+  test('no longer invokes the bespoke cdk-cicd check umbrella', () => {
+    expect(commands.join(' ')).not.toContain('cdk-cicd check');
+  });
+});

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
@@ -92,6 +92,10 @@ describe('defaultCiCommands: runtime behaviour in /bin/sh (the CodeBuild shell)'
     // so the `!= "{}"` guard takes the warn branch instead of trying to `npm run` a nonexistent script.
     const { output, code } = run(project({ build: 'true' }));
     expect(output).toContain('WARNING');
+    // The script name must survive into the printed warning intact. It is double-quoted inside a
+    // single-quoted echo; an embedded single quote would close that echo quote in /bin/sh and the
+    // name would be stripped from the output -- so assert the exact `"audit"` token round-trips.
+    expect(output).toContain('"audit"');
     expect(output).not.toContain('AUDIT_RAN');
     expect(code).toBe(0);
   });

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
@@ -4,7 +4,18 @@
 // Unit tests for the shared default CI build commands: the golden-path scripts (audit/build/test)
 // each run-or-warn, in order, with npm ci first. The engines are responsible for appending cdk synth
 // and for replacing this default when ci.steps is set -- those are covered in the engine tests.
+//
+// Beyond the string shape, the run-or-warn snippet is EXECUTED in /bin/sh (the CodeBuild default shell)
+// against real package.json fixtures. Its whole value is runtime behaviour -- whether `npm pkg get`
+// reports a missing script as `{}`, whether a present script runs, whether an absent one warns without
+// failing the build, and whether a failing script propagates its non-zero exit -- none of which the
+// synthesized-string assertions can prove. These guard against an npm-version change to `npm pkg get`
+// or a shell-quoting regression silently turning the gate into a no-op.
 
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { defaultCiCommands } from '../../src/engine/ci-commands';
 
 describe('defaultCiCommands', () => {
@@ -41,5 +52,52 @@ describe('defaultCiCommands', () => {
 
   test('no longer invokes the bespoke cdk-cicd check umbrella', () => {
     expect(commands.join(' ')).not.toContain('cdk-cicd check');
+  });
+});
+
+describe('defaultCiCommands: runtime behaviour in /bin/sh (the CodeBuild shell)', () => {
+  // The exact snippet the engines drop into the buildspec for the `audit` script.
+  const auditCmd = defaultCiCommands()[1];
+  const dirs: string[] = [];
+
+  /** A throwaway project whose package.json has exactly the given scripts. */
+  function project(scripts: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-cicd-ci-cmd-'));
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0', scripts }));
+    dirs.push(dir);
+    return dir;
+  }
+
+  /** Run the snippet in /bin/sh from `cwd`; return its stdout+stderr and exit code. */
+  function run(cwd: string): { output: string; code: number } {
+    try {
+      const output = execFileSync('/bin/sh', ['-c', auditCmd], { cwd, encoding: 'utf8', stdio: 'pipe' });
+      return { output, code: 0 };
+    } catch (e) {
+      const err = e as { status?: number; stdout?: string; stderr?: string };
+      return { output: `${err.stdout ?? ''}${err.stderr ?? ''}`, code: err.status ?? -1 };
+    }
+  }
+
+  afterAll(() => dirs.forEach((dir) => fs.rmSync(dir, { recursive: true, force: true })));
+
+  test('a present script runs and exits 0', () => {
+    const { output, code } = run(project({ audit: 'echo AUDIT_RAN' }));
+    expect(output).toContain('AUDIT_RAN');
+    expect(code).toBe(0);
+  });
+
+  test('a missing script warns and exits 0 (the build continues)', () => {
+    // This is the load-bearing case: `npm pkg get scripts.audit` must report the absent key as `{}`
+    // so the `!= "{}"` guard takes the warn branch instead of trying to `npm run` a nonexistent script.
+    const { output, code } = run(project({ build: 'true' }));
+    expect(output).toContain('WARNING');
+    expect(output).not.toContain('AUDIT_RAN');
+    expect(code).toBe(0);
+  });
+
+  test('a present script that fails propagates its non-zero exit (the build fails)', () => {
+    const { code } = run(project({ audit: 'exit 7' }));
+    expect(code).not.toBe(0);
   });
 });

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Unit tests for the shared default CI build commands: the golden-path scripts (audit/build/test)
+// Unit tests for the shared default CI build commands: the default scripts (audit/build/test)
 // each run-or-warn, in order, with npm ci first. The engines are responsible for appending cdk synth
 // and for replacing this default when ci.steps is set -- those are covered in the engine tests.
 //

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/ci-commands.test.ts
@@ -105,3 +105,40 @@ describe('defaultCiCommands: runtime behaviour in /bin/sh (the CodeBuild shell)'
     expect(code).not.toBe(0);
   });
 });
+
+describe('pipeline synth: npm run cdk synth (never npx -- npx is non-deterministic and banned)', () => {
+  // The engines append `npm run cdk synth`, not `npx cdk synth`, so the project's pinned aws-cdk is used
+  // deterministically. That REQUIRES the CDK app to expose a `cdk` script in package.json -- the expected
+  // project shape (see the CI guide). These tests pin that contract: it resolves the project's own script,
+  // and a project missing it fails loudly rather than silently pulling an unpinned cdk.
+  const dirs: string[] = [];
+  function project(scripts: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-cicd-synth-'));
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0', scripts }));
+    dirs.push(dir);
+    return dir;
+  }
+  function runCmd(cwd: string, cmd: string): { output: string; code: number } {
+    try {
+      const output = execFileSync('/bin/sh', ['-c', cmd], { cwd, encoding: 'utf8', stdio: 'pipe' });
+      return { output, code: 0 };
+    } catch (e) {
+      const err = e as { status?: number; stdout?: string; stderr?: string };
+      return { output: `${err.stdout ?? ''}${err.stderr ?? ''}`, code: err.status ?? -1 };
+    }
+  }
+  afterAll(() => dirs.forEach((dir) => fs.rmSync(dir, { recursive: true, force: true })));
+
+  test('runs the project cdk script when present (a real "cdk" script stands in for the aws-cdk bin)', () => {
+    // The fixture's `cdk` script echoes a marker instead of invoking the real CLI; the point is that
+    // `npm run cdk synth` resolves the PROJECT's script (deterministic), not an ambient/npx-fetched cdk.
+    const { output, code } = runCmd(project({ cdk: 'echo CDK_SCRIPT_RAN' }), 'npm run cdk synth');
+    expect(output).toContain('CDK_SCRIPT_RAN');
+    expect(code).toBe(0);
+  });
+
+  test('fails loudly when the project has no cdk script (the prerequisite the CI guide documents)', () => {
+    const { code } = runCmd(project({ build: 'true' }), 'npm run cdk synth');
+    expect(code).not.toBe(0);
+  });
+});

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/codepipeline/CodePipelineEngine.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/codepipeline/CodePipelineEngine.test.ts
@@ -151,13 +151,32 @@ describe('m4-codepipeline: CodePipelineEngine', () => {
     });
   });
 
-  test('the default CI run invokes the project golden-path scripts (audit/build/test), not a bespoke CLI', () => {
+  test('the default CI run invokes the project npm scripts (audit/build/test), not a bespoke CLI', () => {
     const config = defineCICD({ application: 'shop', repository: Repository.s3('shop-src/app.zip'), stages: ['dev'] });
     // The default build phase runs the project's own npm scripts, each run-only-if-present with a
     // warning otherwise -- so the checks are encouraged guidance, discoverable and local==CI.
     render(config).hasResourceProperties('AWS::CodeBuild::Project', {
       Source: { BuildSpec: Match.stringLikeRegexp('npm run audit') },
     });
+  });
+
+  test('custom ci.steps are the build phase verbatim -- the engine injects no npm ci of its own', () => {
+    // A project that configures ci.steps owns its build phase, including whether/where `npm ci` runs.
+    // The engine must not prepend one: the CI build commands are exactly the configured steps, in order.
+    const config = defineCICD({
+      application: 'shop',
+      repository: Repository.s3('shop-src/app.zip'),
+      stages: ['dev'],
+      ci: { steps: { install: 'npm ci --ignore-scripts', build: 'npm run build' } },
+    });
+    const spec = specContaining(render(config), 'npm run build');
+    // The build commands begin with the user's OWN first step, not an engine-injected `npm ci`, and
+    // synth is still appended after.
+    expect(spec.phases.build.commands[0]).toBe('npm ci --ignore-scripts');
+    expect(spec.phases.build.commands).toContain('npm run build');
+    // Exactly one `npm ci ...` -- the user's -- not a duplicate injected before it.
+    const npmCiCount = spec.phases.build.commands.filter((c: string) => c.startsWith('npm ci')).length;
+    expect(npmCiCount).toBe(1);
   });
 
   test('a codeArtifact config logs every build project into the private repo before npm ci', () => {

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/codepipeline/CodePipelineEngine.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/codepipeline/CodePipelineEngine.test.ts
@@ -151,11 +151,12 @@ describe('m4-codepipeline: CodePipelineEngine', () => {
     });
   });
 
-  test('the default CI run includes the checks, so validate/audit/license/security are default-on', () => {
+  test('the default CI run invokes the project golden-path scripts (audit/build/test), not a bespoke CLI', () => {
     const config = defineCICD({ application: 'shop', repository: Repository.s3('shop-src/app.zip'), stages: ['dev'] });
-    // Without this the checks exist as a CLI command nobody in CI ever calls.
+    // The default build phase runs the project's own npm scripts, each run-only-if-present with a
+    // warning otherwise -- so the checks are encouraged guidance, discoverable and local==CI.
     render(config).hasResourceProperties('AWS::CodeBuild::Project', {
-      Source: { BuildSpec: Match.stringLikeRegexp('cdk-cicd check') },
+      Source: { BuildSpec: Match.stringLikeRegexp('npm run audit') },
     });
   });
 
@@ -1025,7 +1026,7 @@ describe('m4-codepipeline: CodePipelineEngine', () => {
           }),
         },
       });
-      const build = specContaining(render(config), 'cdk-cicd check');
+      const build = specContaining(render(config), 'npm run audit');
 
       // The user's fragment lands on the CI build project's spec...
       expect(build.env.variables.CUSTOM_VAR).toBe('custom-value');
@@ -1033,7 +1034,8 @@ describe('m4-codepipeline: CodePipelineEngine', () => {
       // ...WITHOUT dropping the engine's own generated content -- a naive `replace` here would drop the
       // Node runtime pin and the default CI commands, and a real pipeline would break silently.
       expect(build.phases.install['runtime-versions'].nodejs).toBeGreaterThanOrEqual(20);
-      expect(build.phases.build.commands).toEqual(expect.arrayContaining(['npm ci', 'npx cdk-cicd check']));
+      expect(build.phases.build.commands[0]).toBe('npm ci');
+      expect(build.phases.build.commands.some((c: string) => c.includes('npm run audit'))).toBe(true);
     });
 
     test('the merge is scoped to the CI build project; self-update and stage deploys are untouched', () => {
@@ -1063,7 +1065,7 @@ describe('m4-codepipeline: CodePipelineEngine', () => {
         repository: Repository.s3('shop-src/app.zip'),
         stages: ['dev'],
       });
-      const build = specContaining(render(config), 'cdk-cicd check');
+      const build = specContaining(render(config), 'npm run audit');
       expect(build.env).toBeUndefined();
     });
   });

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/github/GitHubActionsEngine.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/github/GitHubActionsEngine.test.ts
@@ -149,11 +149,13 @@ describe('GitHubActionsEngine', () => {
     expect(yaml).not.toContain('Token[');
   });
 
-  test('the Synth job runs npm ci + cdk-cicd check + cdk synth', () => {
+  test('the Synth job runs npm ci + the golden-path scripts + cdk synth', () => {
     const { engine } = render();
     const yaml = engine.pipeline.workflowFile.toYaml();
     expect(yaml).toContain('npm ci');
-    expect(yaml).toContain('npx cdk-cicd check');
+    expect(yaml).toContain('npm run audit');
+    expect(yaml).toContain('npm run build');
+    expect(yaml).toContain('npm run test');
     expect(yaml).toContain('npx cdk synth');
   });
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/github/GitHubActionsEngine.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/github/GitHubActionsEngine.test.ts
@@ -149,14 +149,16 @@ describe('GitHubActionsEngine', () => {
     expect(yaml).not.toContain('Token[');
   });
 
-  test('the Synth job runs npm ci + the golden-path scripts + cdk synth', () => {
+  test('the Synth job runs npm ci + the default scripts + npm run cdk synth', () => {
     const { engine } = render();
     const yaml = engine.pipeline.workflowFile.toYaml();
     expect(yaml).toContain('npm ci');
     expect(yaml).toContain('npm run audit');
     expect(yaml).toContain('npm run build');
     expect(yaml).toContain('npm run test');
-    expect(yaml).toContain('npx cdk synth');
+    // Synth via `npm run cdk` so the project's pinned aws-cdk is used, not whatever npx resolves.
+    expect(yaml).toContain('npm run cdk synth');
+    expect(yaml).not.toContain('npx cdk synth');
   });
 
   test('each stage gets its own GitHub Environment named after the stage', () => {


### PR DESCRIPTION
## What

Changes the **default CI build phase** (when no `ci.steps` are configured) from the bespoke `npx cdk-cicd check` umbrella to the project's own golden-path npm scripts, run in order:

```
npm ci
npm run audit   # if package.json defines it; else a warning + docs pointer, continue
npm run build   # if defined; else warning
npm run test    # if defined; else warning
npx cdk synth   # unchanged, always appended
```

A missing script prints a warning that points at the recommended checks and **continues** — it never fails the build. This treats the checks as encouraged guidance rather than hard enforcement, keeps CI identical to what developers run locally, and removes the build-time `npx better-npm-audit@3.7.3` internet fetch from the default path.

## Why

- **Golden-path ergonomics / local==CI parity.** `npm run audit`/`build`/`test` are greppable in `package.json` and behave identically on a laptop and in CI, unlike an opaque umbrella CLI.
- **No build-time internet pull.** The old default reached the registry for `better-npm-audit` at build time (not in the lockfile) — a supply-chain smell. The golden-path default uses whatever the project has pinned.
- **Guidance, not enforcement.** Missing scripts warn instead of failing, so a project opts in to each check by defining the script.

## How

- New shared `defaultCiCommands()` helper (`src/engine/ci-commands.ts`) renders the same default across all three engines. Presence is probed with `npm pkg get scripts.<name>` (no `jq`); the run-or-warn snippet never exits non-zero.
- Wired into `CodePipelineEngine` (main CI build **and** the container-mode deployer-image build), `CdkPipelinesEngine`, and `GitHubActionsEngine`.
- `ci.steps` still replaces the default wholesale — a customized build owns its phase (no warnings injected).

## Breaking change

Pipelines that relied on the default `cdk-cicd check` running `validate`/`license`/`security` in CI will no longer run those by default. Add them back via `ci.steps` or as `package.json` scripts the default build runs (e.g. `"audit": "cdk-cicd check-dependencies --npm"`).

## Tested

- `npx projen compile` clean, `npx projen eslint` clean.
- Engine test suites updated to assert the golden-path commands; new `test/engine/ci-commands.test.ts` covers the run-or-warn shape, order, and doc pointer. **109/109 engine tests pass** (full package suite: 307 passing, 1 pre-existing skip).
- Docs updated: CI guide, security guide, getting-started, overview, and the autopilot workshop.

## Scope note

The `audit.md` `--level`/`--exclude`/`.nsprc` documentation and the `cli/index.md` command reference are intentionally **not** in this PR — they belong with a separate CLI PR (configurable audit level + CVE suppression) whose code they depend on.
