### PR TITLE
chore(deps): bump cdk-nag from 2.28.0 to 2.37.55

### DIFF
--- a/package-verification.json
+++ b/package-verification.json
@@ -7,5 +7,5 @@
     "test/fixtures/pipeline-app/package.json": "112ecd39b9f84f3937cd418f1869065bf21f8dffe2b8ad49402682318867ed79",
     "projectList": "28124334acbc836c6d4da4d2ad1c288c94e43d4d51ab3ee9ca3f5b92c5a5df85"
   },
-  "npm-lock-file": "fa5177eca06919031fc247803878c7df6175b8bca407ffa1e2a03cd6fcf35bd3"
+  "npm-lock-file": "4f09fe451db7ec5ee355f746337be1e1274b79e85227318e868094076cb8ef23"
 }

--- a/packages/@cdklabs/cdk-cicd-wrapper/.projen/deps.json
+++ b/packages/@cdklabs/cdk-cicd-wrapper/.projen/deps.json
@@ -131,7 +131,7 @@
     },
     {
       "name": "cdk-nag",
-      "version": "^2.28.0",
+      "version": "^2.37.55",
       "type": "peer"
     },
     {

--- a/packages/@cdklabs/cdk-cicd-wrapper/package.json
+++ b/packages/@cdklabs/cdk-cicd-wrapper/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/parser": "^7",
     "@typescript-eslint/typescript-estree": "^7",
     "aws-cdk-lib": "2.195.0",
-    "cdk-nag": "2.28.0",
+    "cdk-nag": "2.37.55",
     "cdk-pipelines-github": "0.4.139",
     "commit-and-tag-version": "^12",
     "constructs": "10.5.0",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.195.0",
-    "cdk-nag": "^2.28.0",
+    "cdk-nag": "^2.37.55",
     "cdk-pipelines-github": "^0.4.132",
     "constructs": "^10.5.0"
   },

--- a/projenrc/RootConfig.ts
+++ b/projenrc/RootConfig.ts
@@ -23,7 +23,7 @@ export class RootConfig extends yarn.Monorepo {
   public readonly workflowRunsOn = ['ubuntu-latest'];
   public readonly cdkVersion = '2.195.0';
   public readonly integVersion = '2.186.0';
-  public readonly cdkNagVersion = '2.28.0';
+  public readonly cdkNagVersion = '2.37.55';
   public readonly constructsVersion = CONSTRUCTS_VERSION;
   public readonly authorName = 'CDK CI/CD Wrapper Team';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3446,10 +3446,10 @@ case@1.6.3, case@^1.6.3:
   resolved "https://registry.npmjs.org/case/-/case-1.6.3.tgz"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk-nag@2.28.0:
-  version "2.28.0"
-  resolved "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.0.tgz"
-  integrity sha512-LhobvJwo9QZ1k9i4iQW/XWANGwFTvLj6JCpbPqU709cBKu6B9c4lbFQUPl2qegEsWz8P76DcawwWxvJ9bDRaQw==
+cdk-nag@2.37.55:
+  version "2.37.55"
+  resolved "https://registry.yarnpkg.com/cdk-nag/-/cdk-nag-2.37.55.tgz#438f6bb99a08bedee8c8067a0a16ede952a5f10e"
+  integrity sha512-xcAkygwbph3pp7N0UEzJBmXUH/MIsluV7DYJSeZ/V3yCr0Y0QaRGO298WyD6mi4K+Rmnpl+EJoWUxcOblOqLKA==
 
 cdk-pipelines-github@0.4.139:
   version "0.4.139"


### PR DESCRIPTION
## Description

Supersedes #263. cdk-nag is a **projen-managed** dependency pinned via `cdkNagVersion` in `projenrc/RootConfig.ts` and consumed as `cdk-nag@^${cdkNagVersion}` in `projenrc/PipelineConfig.ts`. Dependabot edits the *generated* `package.json`, but `npx projen build` regenerates it from the source pin — reverting the bump — so #263's `build` check can never converge and it never auto-merges.

This bumps the source-of-truth pin instead and regenerates.

## Changes

- `projenrc/RootConfig.ts`: `cdkNagVersion` 2.28.0 → 2.37.55
- Regenerated `package.json` + `.projen/deps.json` (peer `cdk-nag@^2.37.55`)
- `yarn.lock` updated; `package-verification.json` checksum recorded so strict `validate` passes

## Testing

- [x] `npx projen build` green — 515 tests pass (34+9 suites)
- [x] Build converges (second build produces zero mutation)
- [x] cdk-nag 2.37.55 introduces no new failing nag rules
- [x] Strict `cdk-cicd validate` passes (lock checksum recorded)

Closes #263