### PR TITLE
feat: create CodeCommit source repositories by default (Blueprint parity)

### DIFF
--- a/docs/content/developer_guides/configuration.md
+++ b/docs/content/developer_guides/configuration.md
@@ -91,6 +91,8 @@ Repository.codecommit('my-repo'); // AWS CodeCommit
 Repository.codestarConnection('my-org/my-app', connArn); // any provider via an existing connection ARN
 Repository.s3('my-bucket/my-key'); // a versioned S3 object
 // each factory takes an optional trailing `branch` argument, e.g. Repository.github('my-org/my-app', 'develop')
+// CodeCommit is CREATED by default; pass { existing: true } to import an existing repo instead:
+Repository.codecommit('my-repo', 'main', { existing: true });
 ```
 
 When `engine` is `GITHUB_ACTIONS`, `repository` must be `Repository.github(...)` — the workflow runs

--- a/docs/content/developer_guides/vcs_codecommit.md
+++ b/docs/content/developer_guides/vcs_codecommit.md
@@ -22,7 +22,19 @@ Pass a second argument to track a different branch:
 repository: Repository.codecommit('my-repo', 'trunk'),
 ```
 
-`Repository.codecommit(...)` is a bare source selector — it only names the CodeCommit repository the pipeline reads from. Unlike Blueprint (0.x)'s `RepositorySource.codecommit(...)`, there is no `enableCodeGuruReviewer`/`enablePullRequestChecks` option: Amazon CodeGuru Reviewer pull-request automation is **not** part of Autopilot. If you relied on that, `cdk-cicd security-scan`/`cdk-cicd check` (Bandit, Semgrep, ShellCheck, dependency audit — see the [Security guide](./security.md)) run in the pipeline's CI build instead, but they are not PR-time checks against a CodeCommit pull request specifically.
+## Repository creation
+
+By default, `Repository.codecommit('my-repo')` **creates** the CodeCommit repository as part of the pipeline stack — so a single `cdk-cicd deploy-ci` gives you both the pipeline and an empty repository to push to. This matches the Blueprint (0.x) behaviour, where naming a CodeCommit source provisioned the repository for you.
+
+If the repository already exists (for example, it is managed elsewhere, or shared across pipelines), pass `{ existing: true }` to import it by name instead of creating it:
+
+```typescript
+repository: Repository.codecommit('my-repo', 'main', { existing: true }),
+```
+
+An imported repository must already exist at deploy time; a created one is provisioned with the CDK default removal policy (retained on stack deletion, so your source history is not lost).
+
+`Repository.codecommit(...)` names the CodeCommit repository the pipeline reads from. Unlike Blueprint (0.x)'s `RepositorySource.codecommit(...)`, there is no `enableCodeGuruReviewer`/`enablePullRequestChecks` option: Amazon CodeGuru Reviewer pull-request automation is **not** part of Autopilot. If you relied on that, `cdk-cicd security-scan`/`cdk-cicd check` (Bandit, Semgrep, ShellCheck, dependency audit — see the [Security guide](./security.md)) run in the pipeline's CI build instead, but they are not PR-time checks against a CodeCommit pull request specifically.
 
 ## Pushing to the repository
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/API.md
+++ b/packages/@cdklabs/cdk-cicd-wrapper/API.md
@@ -1934,6 +1934,44 @@ Defaults to the pipeline's own region.
 
 ---
 
+### CodeCommitSourceOptions <a name="CodeCommitSourceOptions" id="@cdklabs/cdk-cicd-wrapper.CodeCommitSourceOptions"></a>
+
+Options for a CodeCommit source.
+
+#### Initializer <a name="Initializer" id="@cdklabs/cdk-cicd-wrapper.CodeCommitSourceOptions.Initializer"></a>
+
+```typescript
+import { CodeCommitSourceOptions } from '@cdklabs/cdk-cicd-wrapper'
+
+const codeCommitSourceOptions: CodeCommitSourceOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/cdk-cicd-wrapper.CodeCommitSourceOptions.property.existing">existing</a></code> | <code>boolean</code> | Whether the CodeCommit repository already exists. |
+
+---
+
+##### `existing`<sup>Optional</sup> <a name="existing" id="@cdklabs/cdk-cicd-wrapper.CodeCommitSourceOptions.property.existing"></a>
+
+```typescript
+public readonly existing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether the CodeCommit repository already exists.
+
+When `false` (the default), the pipeline **creates** the CodeCommit repository as part of its own
+stack -- matching the Blueprint (0.x) behaviour, where naming a CodeCommit source provisioned the
+repository for you. When `true`, the repository must already exist and the pipeline only imports
+it by name.
+
+---
+
 ### CodePipelineEngineProps <a name="CodePipelineEngineProps" id="@cdklabs/cdk-cicd-wrapper.CodePipelineEngineProps"></a>
 
 Options for the CodePipeline engine.
@@ -4980,10 +5018,13 @@ cleanly in every jsii language.
 ```typescript
 import { Repository } from '@cdklabs/cdk-cicd-wrapper'
 
-Repository.codecommit(name: string, branch?: string)
+Repository.codecommit(name: string, branch?: string, options?: CodeCommitSourceOptions)
 ```
 
 An AWS CodeCommit repository by name.
+
+By default the pipeline **creates** the repository (Blueprint
+parity); pass `{ existing: true }` to import a repository that already exists instead.
 
 ###### `name`<sup>Required</sup> <a name="name" id="@cdklabs/cdk-cicd-wrapper.Repository.codecommit.parameter.name"></a>
 
@@ -4994,6 +5035,12 @@ An AWS CodeCommit repository by name.
 ###### `branch`<sup>Optional</sup> <a name="branch" id="@cdklabs/cdk-cicd-wrapper.Repository.codecommit.parameter.branch"></a>
 
 - *Type:* string
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="@cdklabs/cdk-cicd-wrapper.Repository.codecommit.parameter.options"></a>
+
+- *Type:* <a href="#@cdklabs/cdk-cicd-wrapper.CodeCommitSourceOptions">CodeCommitSourceOptions</a>
 
 ---
 
@@ -5077,6 +5124,7 @@ A versioned S3 object (`bucket/key`) as the source.
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.Repository.property.name">name</a></code> | <code>string</code> | Provider-specific identifier: `owner/repo` for GitHub, the repository/bucket name otherwise. |
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.Repository.property.repositoryType">repositoryType</a></code> | <code><a href="#@cdklabs/cdk-cicd-wrapper.RepositorySourceType">RepositorySourceType</a></code> | The kind of source. |
 | <code><a href="#@cdklabs/cdk-cicd-wrapper.Repository.property.connectionArn">connectionArn</a></code> | <code>string</code> | The CodeStar/CodeConnections connection ARN, set only for `CODESTAR_CONNECTION`. |
+| <code><a href="#@cdklabs/cdk-cicd-wrapper.Repository.property.existing">existing</a></code> | <code>boolean</code> | For a CodeCommit source, whether the repository already exists (import-only). |
 
 ---
 
@@ -5127,6 +5175,21 @@ public readonly connectionArn: string;
 - *Type:* string
 
 The CodeStar/CodeConnections connection ARN, set only for `CODESTAR_CONNECTION`.
+
+---
+
+##### `existing`<sup>Optional</sup> <a name="existing" id="@cdklabs/cdk-cicd-wrapper.Repository.property.existing"></a>
+
+```typescript
+public readonly existing: boolean;
+```
+
+- *Type:* boolean
+
+For a CodeCommit source, whether the repository already exists (import-only).
+
+When `false` the
+pipeline creates it. Unset for non-CodeCommit sources.
 
 ---
 

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/config/repository.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/config/repository.ts
@@ -14,6 +14,21 @@ export enum RepositorySourceType {
   S3 = 's3',
 }
 
+/** Options for a CodeCommit source. */
+export interface CodeCommitSourceOptions {
+  /**
+   * Whether the CodeCommit repository already exists.
+   *
+   * When `false` (the default), the pipeline **creates** the CodeCommit repository as part of its own
+   * stack -- matching the Blueprint (0.x) behaviour, where naming a CodeCommit source provisioned the
+   * repository for you. When `true`, the repository must already exist and the pipeline only imports
+   * it by name.
+   *
+   * @default false
+   */
+  readonly existing?: boolean;
+}
+
 /**
  * The source repository for an Autopilot pipeline. Constructed through the static factories rather than
  * directly, so the shape a caller writes (`Repository.github('org/repo')`) is the shape that reads
@@ -25,9 +40,12 @@ export class Repository {
     return new Repository(RepositorySourceType.GITHUB, name, branch);
   }
 
-  /** An AWS CodeCommit repository by name. */
-  public static codecommit(name: string, branch?: string): Repository {
-    return new Repository(RepositorySourceType.CODECOMMIT, name, branch);
+  /**
+   * An AWS CodeCommit repository by name. By default the pipeline **creates** the repository (Blueprint
+   * parity); pass `{ existing: true }` to import a repository that already exists instead.
+   */
+  public static codecommit(name: string, branch?: string, options?: CodeCommitSourceOptions): Repository {
+    return new Repository(RepositorySourceType.CODECOMMIT, name, branch, undefined, options?.existing ?? false);
   }
 
   /** A provider reachable through an existing CodeStar/CodeConnections connection ARN. */
@@ -48,11 +66,23 @@ export class Repository {
   public readonly branch: string;
   /** The CodeStar/CodeConnections connection ARN, set only for `CODESTAR_CONNECTION`. */
   public readonly connectionArn?: string;
+  /**
+   * For a CodeCommit source, whether the repository already exists (import-only). When `false` the
+   * pipeline creates it. Unset for non-CodeCommit sources.
+   */
+  public readonly existing?: boolean;
 
-  private constructor(repositoryType: RepositorySourceType, name: string, branch?: string, connectionArn?: string) {
+  private constructor(
+    repositoryType: RepositorySourceType,
+    name: string,
+    branch?: string,
+    connectionArn?: string,
+    existing?: boolean,
+  ) {
     this.repositoryType = repositoryType;
     this.name = name;
     this.branch = branch ?? 'main';
     this.connectionArn = connectionArn;
+    this.existing = existing;
   }
 }

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/cdkpipelines/CdkPipelinesEngine.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/cdkpipelines/CdkPipelinesEngine.ts
@@ -15,7 +15,6 @@
 
 import { Arn, ArnFormat, AspectPriority, Aspects, Environment, Stack, Stage } from 'aws-cdk-lib';
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
-import * as codecommit from 'aws-cdk-lib/aws-codecommit';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as pipelines from 'aws-cdk-lib/pipelines';
@@ -27,6 +26,7 @@ import { AccessLogsForBucketAspect } from '../../support/AccessLogsForBucketAspe
 import { SupportResources } from '../../support/SupportResources';
 import { resolveVpcNetworking } from '../../support/Vpc';
 import { defaultCiCommands } from '../ci-commands';
+import { resolveCodeCommitRepository } from '../codepipeline/source';
 
 /** Context passed to the stage factory for one deployment stage. */
 export interface CdkPipelinesStageContext {
@@ -60,10 +60,7 @@ export interface CdkPipelinesEngineProps {
 function sourceFor(scope: Construct, repository: Repository): pipelines.CodePipelineSource {
   switch (repository.repositoryType) {
     case RepositorySourceType.CODECOMMIT:
-      return pipelines.CodePipelineSource.codeCommit(
-        codecommit.Repository.fromRepositoryName(scope, 'SourceRepo', repository.name),
-        repository.branch,
-      );
+      return pipelines.CodePipelineSource.codeCommit(resolveCodeCommitRepository(scope, repository), repository.branch);
     case RepositorySourceType.GITHUB:
     case RepositorySourceType.CODESTAR_CONNECTION:
       // Both need a CodeStar (CodeConnections) connection ARN to read the git provider.

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/engine/codepipeline/source.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/engine/codepipeline/source.ts
@@ -13,6 +13,21 @@ import {
 import { Construct } from 'constructs';
 import { Repository, RepositorySourceType } from '../../config/repository';
 
+/**
+ * Resolve the CodeCommit repository for a source, creating it by default (Blueprint parity) or importing
+ * it when the caller passed `Repository.codecommit(name, branch, { existing: true })`.
+ *
+ * A created repository is provisioned in the pipeline's own stack; an imported one must already exist.
+ * The construct id is stable (`SourceRepo`) so the create/import switch does not churn the logical id of
+ * downstream resources that reference it.
+ */
+export function resolveCodeCommitRepository(scope: Construct, repository: Repository): codecommit.IRepository {
+  if (repository.existing) {
+    return codecommit.Repository.fromRepositoryName(scope, 'SourceRepo', repository.name);
+  }
+  return new codecommit.Repository(scope, 'SourceRepo', { repositoryName: repository.name });
+}
+
 /** Build the pipeline's source action for the configured repository, writing into `output`. */
 export function buildSourceAction(
   scope: Construct,
@@ -35,7 +50,7 @@ export function buildSourceAction(
     case RepositorySourceType.CODECOMMIT:
       return new actions.CodeCommitSourceAction({
         actionName: 'Source',
-        repository: codecommit.Repository.fromRepositoryName(scope, 'SourceRepo', repository.name),
+        repository: resolveCodeCommitRepository(scope, repository),
         branch: repository.branch,
         output,
       });

--- a/packages/@cdklabs/cdk-cicd-wrapper/src/index.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/src/index.ts
@@ -32,7 +32,7 @@ export { CdkCicd, AttachOptions } from './runtime/attach';
 // being a free function with a union-typed input, is invisible to jsii (Python/Java authoring parity
 // is a later concern -- design open-question O1); the input interfaces (CicdConfigProps/StageInput/
 // StageEnvInput) stay internal to ./config/define for the same union reason.
-export { Repository, RepositorySourceType } from './config/repository';
+export { Repository, RepositorySourceType, CodeCommitSourceOptions } from './config/repository';
 // Container mode (Repo 1): build & push a config-agnostic deployer image to ECR (two-repo split).
 export { BuildImage, BuildImageKind, DockerBuildProps, ImageTagStrategy } from './config/build-image';
 export {

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/config/repository.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/config/repository.test.ts
@@ -21,6 +21,16 @@ describe('m3-config: Repository', () => {
     expect(Repository.s3('bucket/key').repositoryType).toBe(RepositorySourceType.S3);
   });
 
+  test('codecommit creates the repository by default (existing is false)', () => {
+    expect(Repository.codecommit('svc').existing).toBe(false);
+  });
+
+  test('codecommit honours the branch positional and an existing-import option together', () => {
+    const r = Repository.codecommit('svc', 'trunk', { existing: true });
+    expect(r.branch).toBe('trunk');
+    expect(r.existing).toBe(true);
+  });
+
   test('codestarConnection is the only factory that records a connection ARN', () => {
     const arn = 'arn:aws:codestar-connections:us-west-2:111111111111:connection/abc';
     const r = Repository.codestarConnection('org/repo', arn);

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/cdkpipelines/cdk-pipelines-engine.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/cdkpipelines/cdk-pipelines-engine.test.ts
@@ -429,4 +429,26 @@ describe('Blueprint-compat: CdkPipelinesEngine (aws-cdk-lib/pipelines)', () => {
       expect(Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('AwsSolutions-S1'))).toHaveLength(0);
     });
   });
+
+  describe('CodeCommit source repository', () => {
+    function renderWithRepo(repo: Repository): Template {
+      const stack = new Stack(new App(), 'PipelineStack', { env: { account: '111111111111', region: 'us-west-2' } });
+      const engine = new CdkPipelinesEngine(stack, 'Cd', {
+        config: defineCICD({ application: 'shop', repository: repo, stages: ['dev'] }),
+        stages: new StubStages(),
+      });
+      void engine;
+      return Template.fromStack(stack);
+    }
+
+    test('is created by default (Blueprint parity)', () => {
+      const t = renderWithRepo(Repository.codecommit('shop'));
+      t.hasResourceProperties('AWS::CodeCommit::Repository', { RepositoryName: 'shop' });
+    });
+
+    test('is imported, not created, when existing is true', () => {
+      const t = renderWithRepo(Repository.codecommit('shop', undefined, { existing: true }));
+      t.resourceCountIs('AWS::CodeCommit::Repository', 0);
+    });
+  });
 });

--- a/packages/@cdklabs/cdk-cicd-wrapper/test/engine/codepipeline/CodePipelineEngine.test.ts
+++ b/packages/@cdklabs/cdk-cicd-wrapper/test/engine/codepipeline/CodePipelineEngine.test.ts
@@ -122,9 +122,32 @@ describe('m4-codepipeline: CodePipelineEngine', () => {
     });
   });
 
-  test('a CodeCommit repository yields a CodeCommit source action for that repo', () => {
+  test('a CodeCommit repository is created by default (Blueprint parity) and wired as the source', () => {
     const config = defineCICD({ application: 'shop', repository: Repository.codecommit('shop-repo'), stages: ['dev'] });
-    render(config).hasResourceProperties('AWS::CodePipeline::Pipeline', {
+    const template = render(config);
+    // Blueprint parity: naming a CodeCommit source provisions the repository in the pipeline stack.
+    template.hasResourceProperties('AWS::CodeCommit::Repository', { RepositoryName: 'shop-repo' });
+    // ...and the pipeline's Source stage reads from it via a CodeCommit source action.
+    template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
+      Stages: Match.arrayWith([
+        Match.objectLike({
+          Name: 'Source',
+          Actions: Match.arrayWith([Match.objectLike({ ActionTypeId: Match.objectLike({ Provider: 'CodeCommit' }) })]),
+        }),
+      ]),
+    });
+  });
+
+  test('an existing CodeCommit repository is imported, not created', () => {
+    const config = defineCICD({
+      application: 'shop',
+      repository: Repository.codecommit('shop-repo', undefined, { existing: true }),
+      stages: ['dev'],
+    });
+    const template = render(config);
+    // `existing: true` imports by name -- no CodeCommit repository resource is synthesized.
+    template.resourceCountIs('AWS::CodeCommit::Repository', 0);
+    template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
       Stages: Match.arrayWith([
         Match.objectLike({
           Name: 'Source',


### PR DESCRIPTION
## What

Restores the Blueprint (0.x) behaviour where naming a CodeCommit source **provisions** the repository. `Repository.codecommit('my-repo')` now **creates** the CodeCommit repository in the pipeline stack across both self-mutating engines (flat CodePipeline and CDK Pipelines) — so a single `cdk-cicd deploy-ci` yields the pipeline *and* an empty repository to push to.

## Opt-out

Import-only behaviour (the previous default) is available via a new `CodeCommitSourceOptions.existing` flag:

```typescript
repository: Repository.codecommit('my-repo', 'main', { existing: true }),
```

## How

- `Repository.codecommit(name, branch?, options?)` — backward-compatible signature (the `branch` positional is unchanged; `.codecommit('my-repo', 'trunk')` still works). Default `existing: false`.
- A single shared `resolveCodeCommitRepository(scope, repository)` helper carries the create-vs-import decision, used by both the flat CodePipeline `source.ts` and the CDK Pipelines `sourceFor`. The source construct id stays `SourceRepo` so the switch does not churn downstream logical ids.
- Created repos use the CDK default removal policy (retained on stack deletion — source history is not lost).

## Behaviour change

This is a `feat`: consumers who wrote `Repository.codecommit(name)` expecting import-only will now have the repository **created**. Pass `{ existing: true }` to keep importing an existing repo. Documented in the CodeCommit VCS guide and the configuration reference.

## Tests

- Unit: factory default (`existing === false`) + branch/existing combination.
- Per-engine template tests (CodePipeline + CDK Pipelines): repo **created** by default; **not** created (import) when `existing: true`.
- Full build green: 36 suites / 433 tests, eslint + jsii + docgen clean; `API.md` regenerated with `CodeCommitSourceOptions`.

Independent of the Python-support work in #272.