### PR TITLE
fix(docs): render GitHub Actions secret examples

### DIFF
--- a/docs/content/developer_guides/ci.md
+++ b/docs/content/developer_guides/ci.md
@@ -147,8 +147,8 @@ ci: {
     },
     ```
 
-    The workflow contains `${{ secrets.REGISTRY_USERNAME }}` and
-    `${{ secrets.REGISTRY_PASSWORD }}` expressions, never literal credentials. Secret names may use
+    The workflow contains `{% raw %}${{ secrets.REGISTRY_USERNAME }}{% endraw %}` and
+    `{% raw %}${{ secrets.REGISTRY_PASSWORD }}{% endraw %}` expressions, never literal credentials. Secret names may use
     letters, numbers, and underscores, must not start with a number, and must not start with
     `GITHUB_`.
 

--- a/docs/content/developer_guides/configuration.md
+++ b/docs/content/developer_guides/configuration.md
@@ -204,7 +204,7 @@ githubActions: {
 - **`publishAssetsAuthRegion`** — the region the OIDC role is assumed in when publishing assets (not the
   region assets publish to). Defaults to the pipeline stack Region.
 - **`buildContainerCredentials`** — GitHub Actions secret names used to authenticate an external
-  `ci.image` job container. The workflow renders `${{ secrets.NAME }}` expressions; literal credentials
+  `ci.image` job container. The workflow renders `{% raw %}${{ secrets.NAME }}{% endraw %}` expressions; literal credentials
   are never accepted. This does not support private ECR, whose authorization-token exchange cannot run
   before GitHub pulls the job container.
 - **`environmentProtectionConfigured`** — explicit acknowledgement that required-reviewer rules have


### PR DESCRIPTION
## Summary
- prevent MkDocs Macros/Jinja from evaluating literal GitHub Actions secret expressions in the CI guide
- apply the same escaping to the configuration guide so all affected public pages render

## Validation
- `./scripts/build-docs`
- `projen build` (704 library tests, 227 CLI tests)